### PR TITLE
ICON IVM and Version/Revision Filename Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Pending][]
+ - Added initial support for ICON IVM
+ - Added support for version/revision numbers in filenames within Files class constructor from_os
+
 
 ## [0.6.0] - 2017-08-11
  - Many changes since the last note here.

--- a/docs/supported_instruments.rst
+++ b/docs/supported_instruments.rst
@@ -54,7 +54,7 @@ ICON IVM
 --------
 
 .. automodule:: pysat.instruments.icon_ivm
-   :members: __doc__
+   :members: __doc__, remove_icon_names
 
 
 ISS-FPMU

--- a/docs/supported_instruments.rst
+++ b/docs/supported_instruments.rst
@@ -50,6 +50,13 @@ Kp
 .. automodule:: pysat.instruments.sw_kp
    :members: __doc__, filter_geoquiet
 
+ICON IVM
+--------
+
+.. automodule:: pysat.instruments.icon_ivm
+   :members: __doc__
+
+
 ISS-FPMU
 --------
 

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -62,22 +62,19 @@ class Meta(object):
             output_str = 'Metadata for 1D variables\n'
         else:
             output_str = ''
-        # print('Metadata for 1D parameters')
-        # print(self.data)
+
         for ind in self.data.index:
             output_str += ind.ljust(30)
         output_str += '\n\n'
         output_str += 'Tracking the following:\n'
         for col in self.data.columns:
             output_str += col.ljust(30)
-        
-        # output_str += self.data.__str__()
+
         output_str += '\n'
         if recurse:
             for item_name in self.ho_data.keys():
                 output_str += '\n\n'
                 output_str += 'Metadata for '+item_name+'\n'
-                # print(self.ho_data[item_name].data)
                 output_str += self.ho_data[item_name].__repr__(False)
 
         return output_str
@@ -252,6 +249,8 @@ class Meta(object):
 
         elif isinstance(value, Meta):
             # dealing with higher order data set
+            # check in units_label and name_label are the same
+            # don't want inconsistencies!!
             self.ho_data[name] = value
 
     def __getitem__(self, key):

--- a/pysat/instruments/__init__.py
+++ b/pysat/instruments/__init__.py
@@ -2,6 +2,8 @@
 
 
 
-__all__ = ['cosmic2013_gps', 'cnofs_vefi', 'cnofs_ivm', 'cnofs_plp', 'cosmic_gps', 
-           'superdarn_grdex', 'omni_hro', 'rocsat1_ivm', 'champ_star', 'sw_dst', 'sw_kp', 'timed_see']
+__all__ = ['champ_star', 'cnofs_ivm', 'cnofs_plp', 'cnofs_vefi', 'cosmic2013_gps', 'cosmic_gps',
+           'icon_ivm', 'iss_fpmu',
+           'omni_hro', 'rocsat1_ivm', 'superdarn_grdex', 'sw_dst', 'sw_kp', 'timed_see',
+           ]
 from . import *

--- a/pysat/instruments/icon_ivm.py
+++ b/pysat/instruments/icon_ivm.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+
+"""Supports the Ion Velocity Meter (IVM) 
+onboard the Ionospheric Connections (ICON) Explorer. 
+
+Parameters
+----------
+platform : string
+    'icon'
+name : string
+    'ivm'
+tag : string
+    None supported
+sat_id : string
+    'a' or 'b'
+
+Warnings
+--------
+- No download routine as ICON has not yet been launched
+- Data not yet publicly available
+       
+"""
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+import functools
+
+import pandas as pds
+import numpy as np
+
+import pysat
+from . import nasa_cdaweb_methods as cdw
+
+
+platform = 'icon'
+name = 'ivm'
+tags = {'':''}
+sat_ids = {'a':[''], 
+           'b':['']}
+test_dates = {'a':{'':pysat.datetime(2018,1,1)},
+              'b':{'':pysat.datetime(2018,1,1)}}
+
+
+def init(self):
+    """
+    """
+    pass
+
+    return
+
+
+def default(inst):
+    """Default routine to be applied when loading data. Removes redundant naming
+    
+    """
+    
+    remove_icon_names(inst)
+
+
+def load(fnames, tag=None, sat_id=None):
+    """
+    
+    """
+    return pysat.utils.load_netcdf4(fnames, units_label='Units', name_label='Long_Name',  epoch_name='Epoch')
+  
+
+def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
+    """Produce a list of ICON IVM files for both 'a' and 'b' instruments.
+    
+    Notes
+    -----
+    Currently fixed to level-2
+    
+    """
+    
+    desc = None
+    tag = 'level_2'
+    if tag == 'level_1':
+        code = 'L1'
+        desc = None
+    elif tag == 'level_2':
+        code = 'L2'
+        desc = None
+    else:
+        raise ValueError('Unsupported tag supplied: ' + tag)
+        
+    if format_str is None:
+        format_str = 'ICON_'+code+'_IVM-'+sat_id.upper()
+        if desc is not None:
+            format_str += '_' + desc +'_'
+        format_str += '_{year:4d}-{month:02d}-{day:02d}_v{version:02d}r{revision:03d}.NC'
+
+    return pysat.Files.from_os(data_path=data_path,
+                                format_str=format_str)
+
+
+
+def download(inst, start, stop, user=None, password=None):
+    """ICON has not yet been launched."""
+    
+    
+    
+    return
+        
+
+def remove_icon_names(inst, target=None):
+    """Removes leading text on ICON project variable names
+
+    """
+  
+    if target is None:
+        lev = inst.tag
+        if lev == 'level_2':
+            lev = 'L2'
+        elif lev == 'level_0':
+            lev = 'L0'
+        elif lev == 'level_0p':
+            lev = 'L0P'
+        elif lev == 'level_1.5':
+            lev = 'L1-5'
+        elif lev == 'level_1':
+            lev = 'L1'
+        else:
+            raise ValueError('Uknown ICON data level')
+        
+        # get instrument code
+        sid = inst.sat_id.lower()
+        if sid == 'a':
+            sid = 'IVM_A'
+        elif sid == 'b':
+            sid = 'IVM_B'
+        else:
+            raise ValueError('Unknown ICON satellite ID')
+        prepend_str = '_'.join(('ICON', lev, sid)) + '_'
+    else:
+        prepend_str = target
+
+    inst.data.rename(columns=lambda x: x.split(prepend_str)[-1].lower(), inplace=True)
+    inst.meta.data.rename(index=lambda x: x.split(prepend_str)[-1].lower(), inplace=True)
+    orig_keys = inst.meta.ho_data.keys()  
+    for key in orig_keys:
+        new_key = key.split(prepend_str)[-1].lower()
+        inst.meta.ho_data[new_key] = inst.meta.ho_data.pop(key)
+        
+    return    
+

--- a/pysat/instruments/icon_ivm.py
+++ b/pysat/instruments/icon_ivm.py
@@ -18,7 +18,9 @@ Warnings
 --------
 - No download routine as ICON has not yet been launched
 - Data not yet publicly available
-       
+
+R. A. Stoneback
+
 """
 
 from __future__ import print_function
@@ -99,13 +101,26 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 def download(inst, start, stop, user=None, password=None):
     """ICON has not yet been launched."""
     
-    
-    
     return
         
 
 def remove_icon_names(inst, target=None):
     """Removes leading text on ICON project variable names
+
+    Parameters
+    ----------
+    inst : pysat.Instrument
+        ICON associated pysat.Instrument object
+    target : str
+        Leading string to remove. If none supplied,
+        ICON project standards are used to identify and remove
+        leading text
+
+    Returns
+    -------
+    None
+        Modifies Instrument object in place
+
 
     """
   

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -26,10 +26,6 @@ def create_dir(inst=None, temporary_file_list=False):
     import os
     import tempfile
 
-    ## create temporary directory  
-    #dir_name = tempfile.gettempdir()
-    #pysat.utils.set_data_dir(dir_name, store=False)
-    
     if inst is None:
         # create instrument
         inst = pysat.Instrument(platform='pysat', name='testing',
@@ -42,6 +38,7 @@ def create_dir(inst=None, temporary_file_list=False):
         pass
     return
 
+
 def remove_files(inst=None):
     import os
     import shutil
@@ -52,9 +49,7 @@ def remove_files(inst=None):
         if (the_file[0:13] == 'pysat_testing') & (the_file[-19:] == '.pysat_testing_file'):
             file_path = os.path.join(dir, the_file)
             if os.path.isfile(file_path):
-                #print(file_path)
                 os.unlink(file_path)
-                #elif os.path.isdir(file_path): shutil.rmtree(file_path)
 
 
 # create year doy file set
@@ -91,6 +86,7 @@ def list_year_doy_files(tag=None, data_path=None, format_str=None):
     else:
         raise ValueError ('A directory must be passed to the loading routine.')
 
+
 def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     """Return a Pandas Series of every file for chosen satellite data"""  
     
@@ -122,8 +118,6 @@ class TestBasics:
         dir_name = tempfile.gettempdir()
         pysat.utils.set_data_dir(dir_name, store=False)
 
-        t_module = pysat.instruments.pysat_testing
-        #t_module.list_files = list_year_doy_files
         self.testInst = pysat.Instrument(inst_module=pysat.instruments.pysat_testing, 
                                          clean_level='clean',
                                          temporary_file_list=self.temporary_file_list)
@@ -153,7 +147,6 @@ class TestBasics:
         check2 = pds.to_datetime(files.index[0]) == pysat.datetime(2008,1,1)
         check3 = pds.to_datetime(files.index[365]) == pysat.datetime(2008,12,31)
         check4 = pds.to_datetime(files.index[-1]) == pysat.datetime(2009,12,31)
-
         assert(check1 & check2 & check3 & check4)
 
     def test_year_doy_files_no_gap_in_name_direct_call_to_from_os(self):
@@ -171,7 +164,6 @@ class TestBasics:
         check2 = pds.to_datetime(files.index[0]) == pysat.datetime(2008,1,1)
         check3 = pds.to_datetime(files.index[365]) == pysat.datetime(2008,12,31)
         check4 = pds.to_datetime(files.index[-1]) == pysat.datetime(2009,12,31)
-
         assert(check1 & check2 & check3 & check4)
 
     def test_year_month_day_files_direct_call_to_from_os(self):
@@ -189,7 +181,6 @@ class TestBasics:
         check2 = pds.to_datetime(files.index[0]) == pysat.datetime(2008,1,1)
         check3 = pds.to_datetime(files.index[365]) == pysat.datetime(2008,12,31)
         check4 = pds.to_datetime(files.index[-1]) == pysat.datetime(2009,12,31)
-
         assert(check1 & check2 & check3 & check4)
 
     def test_year_month_day_hour_files_direct_call_to_from_os(self):
@@ -228,7 +219,6 @@ class TestBasics:
         check3 = pds.to_datetime(files.index[1]) == pysat.datetime(2008,1,1,0,30)
         check4 = pds.to_datetime(files.index[10]) == pysat.datetime(2008,1,1,5,0)
         check5 = pds.to_datetime(files.index[-1]) == pysat.datetime(2008,1,4)
-
         assert(check1 & check2 & check3 & check4 & check5)
 
     def test_year_month_day_hour_minute_second_files_direct_call_to_from_os(self):
@@ -248,7 +238,6 @@ class TestBasics:
         check2 = pds.to_datetime(files.index[0]) == pysat.datetime(2008,1,1)
         check3 = pds.to_datetime(files.index[1]) == pysat.datetime(2008,1,1,0,0,30)
         check4 = pds.to_datetime(files.index[-1]) == pysat.datetime(2008,1,3)
-
         assert(check1 & check2 & check3 & check4)
 
     def test_year_month_files_direct_call_to_from_os(self):
@@ -293,10 +282,10 @@ class TestBasics:
         re_load(pysat.instruments.pysat_testing)
         assert (np.all(inst.files.files.index == dates))
 
+
 class TestBasicsNoFileListStorage(TestBasics):
     def __init__(self, temporary_file_list=True):
         self.temporary_file_list = temporary_file_list
-
 
 
 class TestInstrumentWithFiles:
@@ -315,9 +304,7 @@ class TestInstrumentWithFiles:
         create_dir(temporary_file_list=self.temporary_file_list)
 
         # create a test instrument, make sure it is getting files from filesystem
-        #import pysat.instruments.pysat_testing
         re_load(pysat.instruments.pysat_testing)
-        #self.stored_files_fcn = pysat.instruments.pysat_testing.list_files
         pysat.instruments.pysat_testing.list_files = list_files
         # create a bunch of files by year and doy
         self.testInst = pysat.Instrument(inst_module=pysat.instruments.pysat_testing, 
@@ -339,7 +326,6 @@ class TestInstrumentWithFiles:
         """Runs after every method to clean up previous testing."""
         remove_files(self.testInst)
         del self.testInst
-        #pysat.instruments.pysat_testing = self.stored_files_fcn
         re_load(pysat.instruments.pysat_testing)
         re_load(pysat.instruments)
         # make sure everything about instrument state is restored
@@ -364,7 +350,6 @@ class TestInstrumentWithFiles:
         assert (np.all(self.testInst.files.files.index == dates))
 
     def test_refresh_on_unchanged_files(self):
-
         start = pysat.datetime(2007,12,31)
         stop = pysat.datetime(2008,1,10)
         dates = pysat.utils.season_date_range(start, stop, freq='100min')
@@ -387,8 +372,8 @@ class TestInstrumentWithFiles:
         
     def test_get_new_files_after_multiple_refreshes(self):
         # create new files and make sure that new files are captured
-        start = pysat.datetime(2008,1,11)
-        stop = pysat.datetime(2008,1,12)
+        start = pysat.datetime(2008, 1, 11)
+        stop = pysat.datetime(2008, 1, 12)
 
         create_files(self.testInst, start, stop, freq='100min',  
                      use_doy=False, 
@@ -398,13 +383,12 @@ class TestInstrumentWithFiles:
         self.testInst.files.refresh()
         self.testInst.files.refresh()        
         new_files = self.testInst.files.get_new()
-
         assert (np.all(new_files.index == dates))
         
     def test_get_new_files_after_adding_files(self):
         # create new files and make sure that new files are captured
-        start = pysat.datetime(2008,1,11)
-        stop = pysat.datetime(2008,1,12)
+        start = pysat.datetime(2008, 1, 11)
+        stop = pysat.datetime(2008, 1, 12)
 
         create_files(self.testInst, start, stop, freq='100min',  
                      use_doy=False, 
@@ -415,8 +399,8 @@ class TestInstrumentWithFiles:
 
     def test_get_new_files_after_adding_files_and_adding_file(self):
         # create new files and make sure that new files are captured
-        start = pysat.datetime(2008,1,11)
-        stop = pysat.datetime(2008,1,12)
+        start = pysat.datetime(2008, 1, 11)
+        stop = pysat.datetime(2008, 1, 12)
 
         create_files(self.testInst, start, stop, freq='100min',  
                      use_doy=False, 
@@ -424,8 +408,8 @@ class TestInstrumentWithFiles:
         dates = pysat.utils.season_date_range(start, stop, freq='100min')
         new_files = self.testInst.files.get_new()
 
-        start = pysat.datetime(2008,1,15)
-        stop = pysat.datetime(2008,1,18)
+        start = pysat.datetime(2008, 1, 15)
+        stop = pysat.datetime(2008, 1, 18)
 
         create_files(self.testInst, start, stop, freq='100min',  
                      use_doy=False, 
@@ -436,8 +420,8 @@ class TestInstrumentWithFiles:
 
     def test_get_new_files_after_deleting_files_and_adding_files(self):
         # create new files and make sure that new files are captured
-        start = pysat.datetime(2008,1,11)
-        stop = pysat.datetime(2008,1,12)
+        start = pysat.datetime(2008, 1, 11)
+        stop = pysat.datetime(2008, 1, 12)
         dates = pysat.utils.season_date_range(start, stop, freq='100min')
         
         # remove files, same number as will be added
@@ -449,12 +433,10 @@ class TestInstrumentWithFiles:
                     #print(file_path)
                     to_be_removed -= 1
                     os.unlink(file_path)
-                    
         # add new files
         create_files(self.testInst, start, stop, freq='100min',  
                      use_doy=False, 
                      root_fname = self.root_fname)
-                     
         # get new files   
         new_files = self.testInst.files.get_new()
 
@@ -462,8 +444,8 @@ class TestInstrumentWithFiles:
 
     def test_files_non_standard_pysat_directory(self):
         # create new files and make sure that new files are captured
-        start = pysat.datetime(2008,1,11)
-        stop = pysat.datetime(2008,1,15)
+        start = pysat.datetime(2008, 1, 11)
+        stop = pysat.datetime(2008, 1, 15)
         dates = pysat.utils.season_date_range(start, stop, freq='100min')
         
         self.testInst = pysat.Instrument(inst_module=pysat.instruments.pysat_testing, 
@@ -488,20 +470,16 @@ class TestInstrumentWithFiles:
                      
         # get new files   
         new_files = self.testInst.files.get_new()
-        #print (dates)
-        #print(self.testInst.files.files.index)
-        #print('new_files ', new_files.index)
         assert (np.all(self.testInst.files.files.index == dates) & 
                 np.all(new_files.index == dates) )
 
     def test_files_non_standard_file_format_template(self):
         # create new files and make sure that new files are captured
-        start = pysat.datetime(2008,1,11)
-        stop = pysat.datetime(2008,1,15)
+        start = pysat.datetime(2008, 1, 11)
+        stop = pysat.datetime(2008, 1, 15)
         dates = pysat.utils.season_date_range(start, stop, freq='1D')
         
         # clear out old files, create new ones
-        # create_dir(self.testInst)
         remove_files(self.testInst)
         create_files(self.testInst, start, stop, freq='1D',  
                      use_doy=False, 
@@ -573,7 +551,6 @@ def create_versioned_files(inst, start=None, stop=None, freq='1D', use_doy=True,
                                                                              version=version, revision=revision))
                 with open(fname, 'w') as f:
                     pass
-                    # f.close()
 
 
 def list_versioned_files(tag=None, sat_id=None, data_path=None, format_str=None):
@@ -581,7 +558,6 @@ def list_versioned_files(tag=None, sat_id=None, data_path=None, format_str=None)
 
     if format_str is None:
         format_str = 'pysat_testing_junk_{year:04d}_{month:02d}_{day:03d}{hour:02d}{min:02d}{sec:02d}_stuff_{version:02d}_{revision:03d}.pysat_testing_file'
-
     if tag is not None:
         if tag == '':
             return pysat.Files.from_os(data_path=data_path,
@@ -607,7 +583,6 @@ class TestInstrumentWithVersionedFiles:
         create_dir(temporary_file_list=self.temporary_file_list)
 
         # create a test instrument, make sure it is getting files from filesystem
-        # import pysat.instruments.pysat_testing
         re_load(pysat.instruments.pysat_testing)
         # self.stored_files_fcn = pysat.instruments.pysat_testing.list_files
         pysat.instruments.pysat_testing.list_files = list_versioned_files
@@ -617,7 +592,6 @@ class TestInstrumentWithVersionedFiles:
                                          temporary_file_list=self.temporary_file_list)
 
         self.root_fname = 'pysat_testing_junk_{year:04d}_{month:02d}_{day:03d}{hour:02d}{min:02d}{sec:02d}_stuff_{version:02d}_{revision:03d}.pysat_testing_file'
-        #'pysat_testing_junk_{year:04d}_gold_{day:03d}_stuff_{month:02d}_{hour:02d}_{min:02d}_{sec:02d}_v{version:02d}_r{revision:03d}.pysat_testing_file'
         start = pysat.datetime(2007, 12, 31)
         stop = pysat.datetime(2008, 1, 10)
         create_versioned_files(self.testInst, start, stop, freq='100min',
@@ -632,7 +606,6 @@ class TestInstrumentWithVersionedFiles:
         """Runs after every method to clean up previous testing."""
         remove_files(self.testInst)
         del self.testInst
-        # pysat.instruments.pysat_testing = self.stored_files_fcn
         re_load(pysat.instruments.pysat_testing)
         re_load(pysat.instruments)
         # make sure everything about instrument state is restored
@@ -741,15 +714,12 @@ class TestInstrumentWithVersionedFiles:
             if (the_file[0:13] == 'pysat_testing') & (the_file[-19:] == '.pysat_testing_file'):
                 file_path = os.path.join(self.testInst.files.data_path, the_file)
                 if os.path.isfile(file_path) & (to_be_removed > 0):
-                    # print(file_path)
                     to_be_removed -= 1
                     os.unlink(file_path)
-
         # add new files
         create_versioned_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
                      root_fname=self.root_fname)
-
         # get new files
         new_files = self.testInst.files.get_new()
 
@@ -783,9 +753,6 @@ class TestInstrumentWithVersionedFiles:
 
         # get new files
         new_files = self.testInst.files.get_new()
-        # print (dates)
-        # print(self.testInst.files.files.index)
-        # print('new_files ', new_files.index)
         assert (np.all(self.testInst.files.files.index == dates) &
                 np.all(new_files.index == dates))
 
@@ -796,11 +763,10 @@ class TestInstrumentWithVersionedFiles:
         dates = pysat.utils.season_date_range(start, stop, freq='1D')
 
         # clear out old files, create new ones
-        # create_dir(self.testInst)
         remove_files(self.testInst)
         create_versioned_files(self.testInst, start, stop, freq='1D',
-                     use_doy=False,
-                     root_fname='pysat_testing_unique_{version:02d}_{revision:03d}_{year:04d}_g_{day:03d}_st.pysat_testing_file')
+                               use_doy=False,
+                               root_fname='pysat_testing_unique_{version:02d}_{revision:03d}_{year:04d}_g_{day:03d}_st.pysat_testing_file')
 
         pysat.instruments.pysat_testing.list_files = list_versioned_files
         self.testInst = pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
@@ -808,8 +774,28 @@ class TestInstrumentWithVersionedFiles:
                                          file_format='pysat_testing_unique_{version:02d}_{revision:03d}_{year:04d}_g_{day:03d}_st.pysat_testing_file',
                                          update_files=True,
                                          temporary_file_list=self.temporary_file_list)
-
         assert (np.all(self.testInst.files.files.index == dates))
+
+    def test_files_when_duplicates_forced(self):
+        # create new files and make sure that new files are captured
+        start = pysat.datetime(2008, 1, 11)
+        stop = pysat.datetime(2008, 1, 15)
+        dates = pysat.utils.season_date_range(start, stop, freq='1D')
+
+        # clear out old files, create new ones
+        remove_files(self.testInst)
+        create_versioned_files(self.testInst, start, stop, freq='1D',
+                               use_doy=False,
+                               root_fname='pysat_testing_unique_{version:02d}_{revision:03d}_{year:04d}_g_{day:03d}_st.pysat_testing_file')
+
+        pysat.instruments.pysat_testing.list_files = list_files
+        self.testInst = pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
+                                         clean_level='clean',
+                                         file_format='pysat_testing_unique_??_???_{year:04d}_g_{day:03d}_st.pysat_testing_file',
+                                         update_files=True,
+                                         temporary_file_list=self.temporary_file_list)
+        assert (np.all(self.testInst.files.files.index == dates))
+
 
 class TestInstrumentWithVersionedFilesNoFileListStorage(TestInstrumentWithVersionedFiles):
     def __init__(self, temporary_file_list=True):

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -18,7 +18,7 @@ import numpy as np
 import sys
 import importlib
 
-exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps']
+exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps', 'icon_ivm']
 
 def safe_data_dir():
     saved_path = pysat.data_dir


### PR DESCRIPTION
Initial upload for NASA ICON Ion Velocity Meter (IVM) support, including basic documentation.

Added support for version and revision numbers in filenames when using the Files.from_os constructor. The most recent version/revision is used when there are conflicting dates. This constructor is used by the generalized support for NASA's CDAWeb.

Added new instruments to the pysat/instruments/__init__