### PR TITLE
Minor Meta cleanup

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1377,29 +1377,6 @@ class Instrument(object):
                             export_dict[key+'_'+ho_key][original_key] = meta_dict[original_key]
 
         return export_dict
-
-    def _ensure_metadata_standards(self):
-        """Copies existing metadata to fill in redundant portions of wider standard.
-    
-        This standard ensures compatibility with multiple standards. As such, there
-        is overlap between some of the formative standards. Copies CatDesc, Units, and Long_Name
-        and FillVal appropriately.
-    
-        """
-    
-        meta_obj = [self.meta]
-        for obj_key in self.meta.ho_data.keys():
-            meta_obj.append(self.meta[obj_key])
-    
-        for obj in meta_obj:
-            for item in obj.keys():
-                # print ('MetaData for ', item)
-                # print (obj[item])
-                # print (obj)
-                obj[item] = {'FieldNam': obj[item, self.name_label]}
-                obj[item] = {'Lablxis': obj[item, 'CatDesc']}
-                obj[item] = {'Labl_Ptr_#': obj[item, 'CatDesc']}
-                obj[item] = {'_FillValue':  obj[item, self.fill_label]}
         
  
     def to_netcdf4(self, fname=None, base_instrument=None, epoch_name='Epoch',

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -240,17 +240,17 @@ class Meta(object):
         Meta
         
         """
-
-        other.units_label = self.units_label
-        other.name_label = self.name_label
-        other.notes_label = self.notes_label
-        other.desc_label = self.desc_label
-        other.plot_label = self.plot_label
-        other.axis_label = self.axis_label
-        other.scale_label = self.scale_label
-        other.min_label = self.min_label
-        other.max_label = self.max_label
-        other.fill_label = self.fill_label
+        other_updated = other.copy()
+        other_updated.units_label = self.units_label
+        other_updated.name_label = self.name_label
+        other_updated.notes_label = self.notes_label
+        other_updated.desc_label = self.desc_label
+        other_updated.plot_label = self.plot_label
+        other_updated.axis_label = self.axis_label
+        other_updated.scale_label = self.scale_label
+        other_updated.min_label = self.min_label
+        other_updated.max_label = self.max_label
+        other_updated.fill_label = self.fill_label
         return other
 
     def accept_default_labels(self, other):
@@ -898,13 +898,14 @@ class Meta(object):
                     raise RuntimeError('Duplicated keys (variable names) across '
                                         'Meta objects in keys_nD().')
                                         
-        #TODO make sure labels between the two objects are the same
+        # make sure labels between the two objects are the same
+        other_updated = self.apply_default_labels(other)
         # concat 1D metadata in data frames to copy of
         # current metadata
-        for key in other.keys():
+        for key in other_updated.keys():
             mdata[key] = other[key]
         # add together higher order data
-        for key in other.keys_nD():
+        for key in other_updated.keys_nD():
             mdata[key] = other[key]
         return mdata
 


### PR DESCRIPTION
Removed unnecessary function. Improved robustness of meta concat function to ensure consistency between labels across the meta objects.