### PR TITLE
Ho meta fix

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1213,7 +1213,7 @@ class Instrument(object):
                 return 'f8'
             elif coltype is np.float32:
                 return 'f4'
-            elif coltype in [str, unicode]:
+            elif issubclass(coltype, basestring):
                 return 'S1'
             else:
                 raise TypeError('Unknown Variable Type' + str(coltype))

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1651,7 +1651,7 @@ class Instrument(object):
                                     new_dict['Depend_1'] = obj_dim_names[-1]
                                     new_dict['Display_Type'] = 'Spectogram'            
                                     new_dict['Var_Type'] = self._get_var_type_code(coltype)
-                                    # print('Frame Writing ', key, col, export_meta[key][col])
+                                    # print('Frame Writing ', key, col, export_meta[key].children[col])
                                     new_dict = self._filter_netcdf4_metadata(new_dict, coltype)
                                     # print ('mid2 ', new_dict)
                                     cdfkey.setncatts(new_dict)
@@ -1725,7 +1725,6 @@ class Instrument(object):
                                                       dims[0])).astype(coltype)
                             for i in range(num):
                                 temp_cdf_data[i, :] = self[i, key].index.values
-
                             cdfkey[:, :] = (temp_cdf_data.astype(coltype) *
                                             1.E-6).astype(coltype)
  

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -895,17 +895,17 @@ class Meta(object):
         # concat 1D metadata in data frames to copy of
         # current metadata
 # <<<<<<< ho_meta_fix
-#         for key in other.keys():
-#             mdata.data.loc[key] = other.data.loc[key]
-#         # add together higher order data
-#         for key in other.keys_nD():
-#             mdata.ho_data[key] = other.ho_data[key]
-# =======
         for key in other_updated.keys():
-            mdata[key] = other_updated[key]
+            mdata.data.loc[key] = other.data.loc[key]
         # add together higher order data
         for key in other_updated.keys_nD():
-            mdata[key] = other_updated[key]
+            mdata.ho_data[key] = other.ho_data[key]
+# =======
+#         for key in other_updated.keys():
+#             mdata[key] = other_updated[key]
+#         # add together higher order data
+#         for key in other_updated.keys_nD():
+#             mdata[key] = other_updated[key]
 
         return mdata
 

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -140,7 +140,7 @@ class Meta(object):
         meta['name4'] = {'meta':meta2}
         # or
         meta['name4'] = meta2
-        meta['name4']['name41']
+        meta['name4'].children['name41']
 
         # mixture of 1D and higher dimensional data
         meta = pysat.Meta()
@@ -340,27 +340,27 @@ class Meta(object):
                     return False
             # do same check on all sub variables within each nD key
             for key in self.keys_nD():
-                keys1 = [i for i in self[key].keys()]
-                keys2 = [i for i in other[key].keys()]
+                keys1 = [i for i in self[key].children.keys()]
+                keys2 = [i for i in other[key].children.keys()]
                 if len(keys1) != len(keys2):
                     return False
                 for key_check in keys1:
                     if key_check not in keys2:
                         return False
                 # check if attributes are the same
-                attrs1 = [i for i in self[key].attrs()]
-                attrs2 = [i for i in other[key].attrs()]
+                attrs1 = [i for i in self[key].children.attrs()]
+                attrs2 = [i for i in other[key].children.attrs()]
                 if len(attrs1) != len(attrs2):
                     return False
                 for attr in attrs1:
                     if attr not in attrs2:
                         return False
                 # now time to check if all elements are individually equal
-                for key2 in self[key].keys():
-                    for attr in self[key].attrs():
-                        if not (self[key][key2, attr] == other[key][key2, attr]):
+                for key2 in self[key].children.keys():
+                    for attr in self[key].children.attrs():
+                        if not (self[key].children[key2, attr] == other[key].children[key2, attr]):
                             try:
-                                if not (np.isnan(self[key][key2, attr]) and np.isnan(other[key][key2, attr])):
+                                if not (np.isnan(self[key].children[key2, attr]) and np.isnan(other[key].children[key2, attr])):
                                     return False
                             except TypeError:
                                 # comparison above gets unhappy with string inputs
@@ -449,42 +449,6 @@ class Meta(object):
                 if len(name) != len(value[key]):
                     raise ValueError('Length of names and inputs must be equal.')
 
-            if 'meta' in value:
-                # process higher order stuff first. Meta inputs could be part of 
-                # larger multiple parameter assignment
-                # so assign the Meta objects via a recursive call, then remove all trace
-                # of names with Meta and continue on with the rest of the function
-                pop_list = []
-                pop_loc = []
-                for j, (item, val) in enumerate(zip(name, value['meta'])):
-                    if val is not None:
-                        # assign meta data, recursive call....
-                        self[item] = val
-                        pop_list.append(item)
-                        pop_loc.append(j)
-
-                # remove 'meta' objects from input so rest of code doesn't
-                # have to deal with them. Already processed.
-                if len(value) > 1:
-                    _ = value.pop('meta')
-                else:
-                    value = {}
-                    name = []
-
-                for item, loc in zip(pop_list[::-1], pop_loc[::-1]):
-                    # remove data names that had a Meta object assigned
-                    # they are not part of any future processing
-                    if len(name) > 1:
-                        _ = name.pop(loc)
-                    else:
-                        name = []
-
-                    # remove place holder data in other values that used
-                    # to have to account for presence of Meta object
-                    # going through backwards so I don't mess with location references
-                    for key in value:
-                        _ = value[key].pop(loc)
-
             # check if 'units' or other base parameters have been provided
             # check against provided labels, case insensitive
             # defaults are filled in so that the actions invoked against
@@ -554,18 +518,31 @@ class Meta(object):
                         new_item_name = self.var_case_name(item_name)
                     # time to actually add the info
                     for item_key in item.keys():
-                        # print ('new_item_name', new_item_name)
-                        # print ('item_key', item_key)
-                        # print ('item[item_key]', item[item_key])
-                        to_be_set = item[item_key]
-                        if hasattr(to_be_set, '__iter__') and not isinstance(to_be_set, basestring):
-                            if isinstance(to_be_set[0], basestring):
-                                self.data.loc[new_item_name, item_key] = '\n\n'.join(to_be_set)
+                        # disallow column name children
+                        if item_key not in ['children', 'meta']:
+                            # print ('new_item_name', new_item_name)
+                            # print ('item_key', item_key)
+                            # print ('item[item_key]', item[item_key])
+                            to_be_set = item[item_key]
+                            if hasattr(to_be_set, '__iter__') and not isinstance(to_be_set, basestring):
+                                if isinstance(to_be_set[0], basestring):
+                                    self.data.loc[new_item_name, item_key] = '\n\n'.join(to_be_set)
+                                else:
+                                    warnings.warn(' '.join(('Array elements are disallowed in meta.',
+                                                  'Dropping input :', item_key)))
                             else:
-                                warnings.warn(' '.join(('Array elements are disallowed in meta.',
-                                              'Dropping input :', item_key)))
-                        else:
-                            self.data.loc[new_item_name, item_key] = to_be_set
+                                self.data.loc[new_item_name, item_key] = to_be_set
+            if 'meta' in value:
+                # process higher order stuff. Meta inputs could be part of 
+                # larger multiple parameter assignment
+                pop_list = []
+                pop_loc = []
+                for j, (item, val) in enumerate(zip(name, value['meta'])):
+                    if val is not None:
+                        # assign meta data, recursive call....
+                        self[item] = val
+                        pop_list.append(item)
+                        pop_loc.append(j)
 
         elif isinstance(value, Series):
             # set data usind standard assignment via a dict
@@ -608,25 +585,40 @@ class Meta(object):
             meta['name']
             
             meta[ 'name1', 'units' ]
+
+            for higher order data
+            
+            meta[ 'name1', 'subvar', 'units' ]
         
         """
         # if key is a tuple, looking at index, column access pattern
         if isinstance(key, tuple):
-            new_index = self.var_case_name(key[0])
-            new_name = self.attr_case_name(key[1])
-            return self.data.loc[new_index, new_name]
+            # if tuple length is 2, index, column
+            if len(key) == 2:
+                new_index = self.var_case_name(key[0])
+                new_name = self.attr_case_name(key[1])
+                return self.data.loc[new_index, new_name]
+            # if tuple length is 3, index, child_index, column
+            elif len(key) == 3:
+                new_index = self.var_case_name(key[0])
+                new_child_index = self.var_case_name(key[1])
+                new_name = self.attr_case_name(key[2])
+                return self._ho_data[new_index].data.loc[new_child_index, new_name]
         else:
             # ensure variable is present somewhere
             if key in self:
                 # get case preserved string for variable name
                 new_key = self.var_case_name(key)
-                # check what kind of variable, single or higher order
-                if new_key in self.keys_nD():
-                    # higher order data
-                    return self.ho_data[new_key]
-                elif new_key in self.keys():
-                    # plain old variable request
-                    return self.data.loc[new_key]
+                if new_key in self.keys():
+                    meta_row = self.data.loc[new_key]
+                    if new_key in self.keys_nD():
+                        meta_row.at['children'] = self.ho_data[new_key]
+                    else:
+                        empty_meta = Meta()
+                        meta_row.at['children'] = empty_meta
+                    return meta_row
+                else:
+                    return pds.Series([self.ho_data[new_key]], index=['children'])
             else:
                 raise KeyError('Key not found in MetaData')
 
@@ -858,7 +850,7 @@ class Meta(object):
                 return i
         # check if attribute present in higher order structures
         for key in self.keys_nD():
-            for i in self[key].attrs():
+            for i in self[key].children.attrs():
                 if lower_name == i.lower():
                     return i
         # nothing was found if still here
@@ -902,10 +894,10 @@ class Meta(object):
         # concat 1D metadata in data frames to copy of
         # current metadata
         for key in other.keys():
-            mdata[key] = other[key]
+            mdata.data.loc[key] = other.data.loc[key]
         # add together higher order data
         for key in other.keys_nD():
-            mdata[key] = other[key]
+            mdata.ho_data[key] = other.ho_data[key]
         return mdata
 
     def copy(self):

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -67,8 +67,8 @@ def load(fnames, tag=None, sat_id=None):
     return pysat.utils.load_netcdf4(fnames, epoch_name='Epoch', 
                                     units_label='Units', name_label='Long_Name', 
                                     notes_label='Var_Notes', desc_label='CatDesc',
-                                    plot_label='FieldNam', axis_label='axis', 
-                                    scale_label='scale',
+                                    plot_label='FieldNam', axis_label='LablAxis', 
+                                    scale_label='ScaleTyp',
                                     min_label='ValidMin', max_label='ValidMax',
                                     fill_label='FillVal')
 

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -64,7 +64,13 @@ def load(fnames, tag=None, sat_id=None):
 
     """
     
-    return pysat.utils.load_netcdf4(fnames, epoch_name='Epoch')
+    return pysat.utils.load_netcdf4(fnames, epoch_name='Epoch', 
+                                    units_label='Units', name_label='Long_Name', 
+                                    notes_label='Var_Notes', desc_label='CatDesc',
+                                    plot_label='FieldNam', axis_label='axis', 
+                                    scale_label='scale',
+                                    min_label='ValidMin', max_label='ValidMax',
+                                    fill_label='FillVal')
 
 
 def list_files(tag=None, sat_id=None, data_path=None, format_str=None):

--- a/pysat/instruments/icon_ivm.py
+++ b/pysat/instruments/icon_ivm.py
@@ -65,7 +65,13 @@ def load(fnames, tag=None, sat_id=None):
     """
     
     """
-    return pysat.utils.load_netcdf4(fnames, units_label='Units', name_label='Long_Name',  epoch_name='Epoch')
+    return pysat.utils.load_netcdf4(fnames, epoch_name='Epoch', 
+                                    units_label='Units', name_label='Long_Name', 
+                                    notes_label='Var_Notes', desc_label='CatDesc',
+                                    plot_label='FieldNam', axis_label='LablAxis', 
+                                    scale_label='ScaleTyp',
+                                    min_label='ValidMin', max_label='ValidMax',
+                                    fill_label='FillVal')
   
 
 def list_files(tag=None, sat_id=None, data_path=None, format_str=None):

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -17,17 +17,18 @@ meta['mlt'] = {'units':'hours', 'long_name':'Magnetic Local Time'}
 meta['slt'] = {'units':'hours', 'long_name':'Solar Local Time'}
 meta['longitude'] = {'units':'degrees', 'long_name':'Longitude'}
 meta['latitude'] = {'units':'degrees', 'long_name':'Latitude'}
-meta['series_profiles'] = {'units':'', 'long_name':'series'}
+series_profile_meta = pysat.Meta()
+series_profile_meta['series_profiles'] = {'units':'', 'long_name':'series'}
+meta['series_profiles'] = {'meta':series_profile_meta, 'units':'', 'long_name':'series'}
 profile_meta = pysat.Meta()
 profile_meta['density'] = {'units':'', 'long_name':'profiles'}
 profile_meta['dummy_str'] = {'units':'', 'long_name':'profiles'}
 profile_meta['dummy_ustr'] = {'units':'', 'long_name':'profiles'}
-meta['profiles'] = profile_meta
+meta['profiles'] = {'meta':profile_meta, 'units':'', 'long_name':'profiles'}
 alt_profile_meta = pysat.Meta()
 alt_profile_meta['density'] = {'units':'', 'long_name':'profiles'}
 alt_profile_meta['fraction'] = {'units':'', 'long_name':'profiles'}
-meta['alt_profiles'] = alt_profile_meta
-
+meta['alt_profiles'] = {'meta':alt_profile_meta, 'units':'', 'long_name':'profiles'}
 
 def init(self):
     self.new_thing=True        

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -15,9 +15,18 @@ meta = pysat.Meta()
 meta['uts'] = {'units':'s', 'long_name':'Universal Time'}
 meta['mlt'] = {'units':'hours', 'long_name':'Magnetic Local Time'}
 meta['slt'] = {'units':'hours', 'long_name':'Solar Local Time'}
+meta['longitude'] = {'units':'degrees', 'long_name':'Longitude'}
+meta['latitude'] = {'units':'degrees', 'long_name':'Latitude'}
+meta['series_profiles'] = {'units':'', 'long_name':'series'}
 profile_meta = pysat.Meta()
 profile_meta['density'] = {'units':'', 'long_name':'profiles'}
+profile_meta['dummy_str'] = {'units':'', 'long_name':'profiles'}
+profile_meta['dummy_ustr'] = {'units':'', 'long_name':'profiles'}
 meta['profiles'] = profile_meta
+alt_profile_meta = pysat.Meta()
+alt_profile_meta['density'] = {'units':'', 'long_name':'profiles'}
+alt_profile_meta['fraction'] = {'units':'', 'long_name':'profiles'}
+meta['alt_profiles'] = alt_profile_meta
 
 
 def init(self):

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -102,7 +102,7 @@ class TestBasics():
         self.meta = self.meta.concat(meta2)
         
         assert (self.meta['new3'].units == 'hey3')
-        assert (self.meta['new4']['new41'].units == 'hey4')
+        assert (self.meta['new4'].children['new41'].units == 'hey4')
 
     @raises(RuntimeError)
     def test_basic_concat_w_ho_collision_strict(self):
@@ -127,8 +127,8 @@ class TestBasics():
         meta2['new3'] = meta3
         self.meta = self.meta.concat(meta2, strict=False)
         
-        assert self.meta['new3']['new41'].units == 'hey4'
-        assert self.meta['new3']['new41'].bob_level == 'max'
+        assert self.meta['new3'].children['new41'].units == 'hey4'
+        assert self.meta['new3'].children['new41'].bob_level == 'max'
         assert self.meta['new2'].units == 'hey'
 
     def test_basic_concat_w_ho_collisions_not_strict(self):
@@ -142,8 +142,8 @@ class TestBasics():
         meta2['new3'] = meta3
         self.meta = self.meta.concat(meta2, strict=False)
         
-        assert self.meta['new3']['new31'].units == 'hey4'
-        assert self.meta['new3']['new31'].bob_level == 'max'
+        assert self.meta['new3'].children['new31'].units == 'hey4'
+        assert self.meta['new3'].children['new31'].bob_level == 'max'
         assert self.meta['new2'].units == 'hey'
 
                                                 
@@ -283,8 +283,8 @@ class TestBasics():
         # for key in meta3.keys_nD():
         #     for key2 in meta3[key].keys():
         #         
-        #         print (meta3[key][key2])
-        #         print (self.meta[key][key2])
+        #         print (meta3[key].children[key2])
+        #         print (self.meta[key].children[key2])
         
         assert not (meta3 == self.meta)                
         assert not (self.meta == meta3)                
@@ -310,8 +310,8 @@ class TestBasics():
         # for key in meta3.keys_nD():
         #     for key2 in meta3[key].keys():
         #         
-        #         print (meta3[key][key2])
-        #         print (self.meta[key][key2])
+        #         print (meta3[key].children[key2])
+        #         print (self.meta[key].children[key2])
 
         assert not (meta3 == self.meta)
         assert not (self.meta == meta3)              
@@ -333,7 +333,7 @@ class TestBasics():
         meta['dm'] = {'units':'hey', 'long_name':'boo'}
         meta['rpa'] = {'units':'crazy', 'long_name':'boo_whoo'}
         self.meta['higher'] = {'meta':meta}
-        assert self.meta['higher'] == meta
+        assert self.meta['higher'].children == meta
 
     def test_assign_higher_order_meta_from_dict_w_multiple(self):
         meta = pysat.Meta()
@@ -344,7 +344,7 @@ class TestBasics():
                                           'long_name':[None, 'boohoo']}
         assert self.meta['lower'].units == 'boo'
         assert self.meta['lower'].long_name == 'boohoo'
-        assert self.meta['higher'] == meta
+        assert self.meta['higher'].children == meta
 
     def test_assign_higher_order_meta_from_dict_w_multiple_2(self):
         meta = pysat.Meta()
@@ -355,7 +355,7 @@ class TestBasics():
                                           'long_name':[None, 'boohoo', None]}
         assert self.meta['lower'].units == 'boo'
         assert self.meta['lower'].long_name == 'boohoo'
-        assert self.meta['higher'] == meta
+        assert self.meta['higher'].children == meta
         
     def test_create_new_metadata_from_old(self):
         meta = pysat.Meta()
@@ -509,23 +509,23 @@ class TestBasics():
 
     def test_repeated_set_Units_wrong_case(self):
         self.meta = pysat.Meta(units_label='Units', name_label='Long_Name')
-        for i in np.arange(1000):
+        for i in np.arange(10):
             self.meta['new'] = {'units': 'hey%d' % i, 'long_name': 'boo%d' % i}
             self.meta['new_%d' % i] = {'units': 'hey%d' % i, 'long_name': 'boo%d' % i}
 
-        for i in np.arange(1000):
-            self.meta['new_500'] = {'units': 'hey%d' % i, 'long_name': 'boo%d' % i}
+        for i in np.arange(10):
+            self.meta['new_5'] = {'units': 'hey%d' % i, 'long_name': 'boo%d' % i}
             self.meta['new_%d' % i] = {'units': 'heyhey%d' % i, 
                                         'long_name': 'booboo%d' % i}
 
         # print (self.meta['new'])
-        assert self.meta['new'].Units == 'hey999'
-        assert self.meta['new'].Long_Name == 'boo999'
-        assert self.meta['new_999'].Units == 'heyhey999'
-        assert self.meta['new_999'].Long_Name == 'booboo999'
+        assert self.meta['new'].Units == 'hey9'
+        assert self.meta['new'].Long_Name == 'boo9'
+        assert self.meta['new_9'].Units == 'heyhey9'
+        assert self.meta['new_9'].Long_Name == 'booboo9'
         # print (self.meta['new_500'])
-        assert self.meta['new_500'].Units == 'hey999'
-        assert self.meta['new_500'].Long_Name == 'boo999'
+        assert self.meta['new_5'].Units == 'hey9'
+        assert self.meta['new_5'].Long_Name == 'boo9'
 
     def test_change_Units_and_Name_case(self):
         self.meta = pysat.Meta(units_label='units', name_label='long_name')
@@ -547,7 +547,7 @@ class TestBasics():
         self.meta.name_label = 'Long_Name'
         # print(self.meta['new'])
         assert ((self.meta['new'].Units == 'hey') & (self.meta['new'].Long_Name == 'boo') &
-            (self.meta['new2']['new21'].Units == 'hey2') & (self.meta['new2']['new21'].Long_Name == 'boo2'))
+            (self.meta['new2'].children['new21'].Units == 'hey2') & (self.meta['new2'].children['new21'].Long_Name == 'boo2'))
 
     @raises(AttributeError)    
     def test_change_Units_and_Name_case_w_ho_wrong_case(self):
@@ -560,7 +560,7 @@ class TestBasics():
         self.meta.name_label = 'Long_Name'
         # print(self.meta['new'])
         assert ((self.meta['new'].units == 'hey') & (self.meta['new'].long_name == 'boo') &
-            (self.meta['new2']['new21'].units == 'hey2') & (self.meta['new2']['new21'].long_name == 'boo2'))
+            (self.meta['new2'].children['new21'].units == 'hey2') & (self.meta['new2'].children['new21'].long_name == 'boo2'))
 
     def test_contains_case_insensitive(self):
         self.meta['new'] = {'units':'hey', 'long_name':'boo'}
@@ -610,9 +610,9 @@ class TestBasics():
         assert (self.meta.attr_case_name('YoYoYo') == 'YoYoYO')
         assert (self.meta['new', 'yoyoyo'] == 'YOLO')
         assert (self.meta['new', 'YoYoYO'] == 'YOLO')
-        assert (self.meta['new2']['new21', 'yoyoyo'] == 'yolo')
-        assert (self.meta['new2']['new21', 'YoYoYO'] == 'yolo')
-        assert (self.meta['new2'].attr_case_name('YoYoYo') == 'YoYoYO')
+        assert (self.meta['new2'].children['new21', 'yoyoyo'] == 'yolo')
+        assert (self.meta['new2'].children['new21', 'YoYoYO'] == 'yolo')
+        assert (self.meta['new2'].children.attr_case_name('YoYoYo') == 'YoYoYO')
 
     def test_get_attribute_name_case_preservation_w_higher_order_2(self):
         self.meta['new'] = {'units':'hey', 'long_name':'boo'}
@@ -625,9 +625,9 @@ class TestBasics():
         assert (self.meta.attr_case_name('YoYoYo') == 'YoYoYO')
         assert (self.meta['new', 'yoyoyo'] == 'YOLO')
         assert (self.meta['NEW', 'YoYoYO'] == 'YOLO')
-        assert (self.meta['new2']['new21', 'yoyoyo'] == 'yolo')
-        assert (self.meta['new2']['new21', 'YoYoYO'] == 'yolo')
-        assert (self.meta['new2'].attr_case_name('YoYoYo') == 'YoYoYO')
+        assert (self.meta['new2'].children['new21', 'yoyoyo'] == 'yolo')
+        assert (self.meta['new2'].children['new21', 'YoYoYO'] == 'yolo')
+        assert (self.meta['new2'].children.attr_case_name('YoYoYo') == 'YoYoYO')
 
 
     def test_get_attribute_name_case_preservation_w_higher_order_reverse_order(self):
@@ -641,9 +641,9 @@ class TestBasics():
         assert (self.meta.attr_case_name('YoYoYo') == 'yoyoyo')
         assert (self.meta['new', 'yoyoyo'] == 'YOLO')
         assert (self.meta['new', 'YoYoYO'] == 'YOLO')
-        assert (self.meta['new2']['new21', 'yoyoyo'] == 'yolo')
-        assert (self.meta['new2']['new21', 'YoYoYO'] == 'yolo')
-        assert (self.meta['new2'].attr_case_name('YoYoYo') == 'yoyoyo')
+        assert (self.meta['new2'].children['new21', 'yoyoyo'] == 'yolo')
+        assert (self.meta['new2'].children['new21', 'YoYoYO'] == 'yolo')
+        assert (self.meta['new2'].children.attr_case_name('YoYoYo') == 'yoyoyo')
 
 
     def test_has_attr_name_case_preservation_w_higher_order_reverse_order(self):

--- a/pysat/utils.py
+++ b/pysat/utils.py
@@ -196,18 +196,22 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None, epoch_name='E
                 else:
                     # dimension is not itself a variable
                     index_key_name  = None                
-                
+
                 # iterate over the variables and grab metadata
                 dim_meta_data = pysat.Meta()
                 for key, clean_key in zip(obj_var_keys, clean_var_keys):
-                    # store attributes in metadata
+                    # store attributes in metadata, exept for dim name
                     meta_dict = {}
                     for nc_key in data.variables[key].ncattrs():
                         meta_dict[nc_key] = data.variables[key].getncattr(nc_key)
                     dim_meta_data[clean_key] = meta_dict
 
                 # print (dim_meta_data)
-                mdata[obj_key_name] = dim_meta_data 
+                dim_meta_dict = {'meta':dim_meta_data}
+                # add top level meta
+                for nc_key in data.variables[obj_key_name].ncattrs():
+                    dim_meta_dict[nc_key] = data.variables[obj_key_name].getncattr(nc_key)
+                mdata[obj_key_name] = dim_meta_dict
                 
                 # iterate over all variables with this dimension and store data
                 # data storage, whole shebang

--- a/pysat/utils.py
+++ b/pysat/utils.py
@@ -198,7 +198,12 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None, epoch_name='E
                     index_key_name  = None                
 
                 # iterate over the variables and grab metadata
-                dim_meta_data = pysat.Meta()
+                dim_meta_data = pysat.Meta(units_label=units_label, name_label=name_label,
+                                           notes_label=notes_label, desc_label=desc_label,
+                                           plot_label=plot_label, axis_label=axis_label,
+                                           scale_label=scale_label,
+                                           min_label=min_label, max_label=max_label,
+                                           fill_label=fill_label)
                 for key, clean_key in zip(obj_var_keys, clean_var_keys):
                     # store attributes in metadata, exept for dim name
                     meta_dict = {}

--- a/pysat/utils.py
+++ b/pysat/utils.py
@@ -213,10 +213,11 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None, epoch_name='E
 
                 # print (dim_meta_data)
                 dim_meta_dict = {'meta':dim_meta_data}
-                # add top level meta
-                for nc_key in data.variables[obj_key_name].ncattrs():
-                    dim_meta_dict[nc_key] = data.variables[obj_key_name].getncattr(nc_key)
-                mdata[obj_key_name] = dim_meta_dict
+                if index_key_name is not None:
+                    # add top level meta
+                    for nc_key in data.variables[obj_key_name].ncattrs():
+                        dim_meta_dict[nc_key] = data.variables[obj_key_name].getncattr(nc_key)
+                    mdata[obj_key_name] = dim_meta_dict
                 
                 # iterate over all variables with this dimension and store data
                 # data storage, whole shebang


### PR DESCRIPTION
Modifies meta to always return a series. If the label corresponds to higher order data, the series will contain the associated meta object in the attribute 'children'.

All meta labels now have first-order keys and may or may not contain children.