### PR TITLE
Meta fixes

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -384,34 +384,61 @@ class Instrument(object):
         long_name = 'name', and units = ''.
         
         """
+        
+        # add data to main pandas.DataFrame, depending upon the input
+        
         if isinstance(new, dict):
+            # input dict must have data in 'data', the rest
+            # is presumed to be metadata
             # metadata should be included in dict
-            self.data[key] = new.pop('data')
-            # pass the rest to meta
+            in_data = new.pop('data')
+            if isinstance(in_data[0], pds.DataFrame):
+                # input is a list_like of frames
+                # this is higher order data
+                ho_meta = _meta.Meta()
+                for ho_key in in_data[0]:
+                    ho_meta[ho_key] = {}
+                self.meta[key] = ho_meta
+            # assign data and any extra metadata
+            self.data[key] = in_data
             self.meta[key] = new
+
         else:
+            # not a dictionary, could have a mixed input
+            # aka slice, and a name
             if isinstance(key, tuple):
+                
                 self.data.ix[key[0], key[1]] = new
                 self.meta[key[1]] = {}
             # If list or series of df handle ho data
             elif hasattr(new, '__getitem__'):
-                if isinstance(new, Series):
-                    self.data[key] = new  
-                    self.meta[key] = {}
-                elif isinstance(new, DataFrame):
+                # if isinstance(new, Series):
+                #     # series input, 1D variable
+                #     self.data[key] = new  
+                #     self.meta[key] = {}
+                if isinstance(new, DataFrame):
+                    # dataframe input allows input of multiple
+                    # 1D variables at once
                     self.data[key] = new[key]
                     for ke in key:
                         self.meta[ke] = {}
                 elif isinstance(new[0], pds.DataFrame):
+                    # input is a list_like of frames
+                    # this is higher order data
                     self.data[key] = new
                     ho_meta = _meta.Meta()
                     for ho_key in new[0]:
                         ho_meta[ho_key] = {}
-                    self.meta.ho_data[key] = ho_meta
+                    self.meta[key] = ho_meta
                 else:
+                    # not one of special ones above
+                    # let pandas sort it out
                     self.data[key] = new  
                     self.meta[key] = {}
             elif isinstance(key, str):
+                # didn't get a list_like thing of data
+                # but we were given a name
+                # try and add it
                 self.data[key] = new  
                 self.meta[key] = {}
             else:

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -456,7 +456,6 @@ class Meta(object):
             lower_keys = [k.lower() for k in value.keys()]
             # dictionary of labels (keys) and values (default value for attribute)
             default_dict = self.default_labels_and_values(name)
-            # for attr, defaults in default_dict: #zip(attrs, default_attrs):
             for attr in default_dict: #zip(attrs, default_attrs):
                 # the metadata default values for attr are in defaults
                 defaults = default_dict[attr]
@@ -550,6 +549,10 @@ class Meta(object):
 
         elif isinstance(value, Meta):
             # dealing with higher order data set
+            
+            # if name is already used in meta object, use that one
+            # with preserved case
+            # otherwise, use name as provided
             if name in self:
                 new_item_name = self.var_case_name(name)
             else:
@@ -571,6 +574,11 @@ class Meta(object):
             value.data.index = new_names
             # assign Meta object now that things are consistent with Meta
             # object settings
+            # but first, make sure there are lower dimension metadata
+            # parameters, passing in an empty dict fills in defaults
+            # if there is no existing metadata info
+            self[new_item_name] = {}
+            # now add to higher order data
             self.ho_data[new_item_name] = value
 
     def __getitem__(self, key):

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -66,9 +66,9 @@ class TestInstrumentQualifier():
                     for tag in info[sat_id].keys():
                         try:
                             inst = pysat.Instrument(inst_module=module, 
-                                                                    tag=tag, 
-                                                                    sat_id=sat_id,
-                                                                    temporary_file_list=True) 
+                                                    tag=tag, 
+                                                    sat_id=sat_id,
+                                                    temporary_file_list=True) 
                             inst.test_dates = module.test_dates
                             self.instruments.append(inst)
                             self.instrument_modules.append(module)
@@ -222,29 +222,37 @@ class TestInstrumentQualifier():
             f.description = ' '.join(('Checking download routine functionality for module: ', inst.platform, inst.name, inst.tag, inst.sat_id))
             yield (f,)
             
-            f = partial(self.check_load, inst)
-            f.description = ' '.join(('Checking load routine functionality for module: ', inst.platform, inst.name, inst.tag, inst.sat_id))
-            yield (f,)
-            
-            inst.clean_level = 'none'
-            f = partial(self.check_load, inst)
-            f.description = ' '.join(('Checking load routine functionality for module with clean level "none": ', inst.platform, inst.name, inst.tag, inst.sat_id))
-            yield (f,)
-
-            inst.clean_level = 'dirty'
-            f = partial(self.check_load, inst)
-            f.description = ' '.join(('Checking load routine functionality for module with clean level "dirty": ', inst.platform, inst.name, inst.tag, inst.sat_id))
-            yield (f,)
-            
-            inst.clean_level = 'dusty'
-            f = partial(self.check_load, inst)
-            f.description = ' '.join(('Checking load routine functionality for module with clean level "dusty": ', inst.platform, inst.name, inst.tag, inst.sat_id))
-            yield (f,)
-
-            inst.clean_level = 'clean'
-            f = partial(self.check_load, inst)
-            f.description = ' '.join(('Checking load routine functionality for module with clean level "clean": ', inst.platform, inst.name, inst.tag, inst.sat_id))
-            yield (f,)
+            # make sure download was successful
+            if len(inst.files.files) > 0:
+                f = partial(self.check_load, inst)
+                f.description = ' '.join(('Checking load routine functionality for module: ', inst.platform, inst.name, inst.tag, inst.sat_id))
+                yield (f,)
+                
+                inst.clean_level = 'none'
+                f = partial(self.check_load, inst)
+                f.description = ' '.join(('Checking load routine functionality for module with clean level "none": ', inst.platform, inst.name, inst.tag, inst.sat_id))
+                yield (f,)
+    
+                inst.clean_level = 'dirty'
+                f = partial(self.check_load, inst)
+                f.description = ' '.join(('Checking load routine functionality for module with clean level "dirty": ', inst.platform, inst.name, inst.tag, inst.sat_id))
+                yield (f,)
+                
+                inst.clean_level = 'dusty'
+                f = partial(self.check_load, inst)
+                f.description = ' '.join(('Checking load routine functionality for module with clean level "dusty": ', inst.platform, inst.name, inst.tag, inst.sat_id))
+                yield (f,)
+    
+                inst.clean_level = 'clean'
+                f = partial(self.check_load, inst)
+                f.description = ' '.join(('Checking load routine functionality for module with clean level "clean": ', inst.platform, inst.name, inst.tag, inst.sat_id))
+                yield (f,)
+            else:
+                print ('Unable to actually download a file.')
+                # raise RuntimeWarning(' '.join(('Download for', inst.platform, inst.name, inst.tag, inst.sat_id, 'was not successful.')))
+                import warnings
+                warnings.warn(' '.join(('Download for', inst.platform, inst.name, inst.tag, inst.sat_id, 'was not successful.')))
+                #TODO need a warning!
 
 
     # Optional support

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -23,7 +23,17 @@ class TestBasics():
     def test_inst_data_assign_meta_default(self):
         self.testInst.load(2009,1)
         self.testInst['help'] = self.testInst['mlt']
+
         assert self.testInst.meta['help', 'long_name'] == 'help'
+        assert self.testInst.meta['help', 'axis'] == 'help'
+        assert self.testInst.meta['help', 'label'] == 'help'
+        assert self.testInst.meta['help', 'notes'] == ''
+        assert np.isnan(self.testInst.meta['help', 'fill'])
+        assert np.isnan(self.testInst.meta['help', 'value_min'])
+        assert np.isnan(self.testInst.meta['help', 'value_max'])
+        assert self.testInst.meta['help', 'units'] == ''
+        assert self.testInst.meta['help', 'desc'] == ''
+        assert self.testInst.meta['help', 'scale'] == 'linear'
 
     def test_inst_data_assign_meta(self):
         self.testInst.load(2009,1)
@@ -31,6 +41,32 @@ class TestBasics():
                                  'units': 'V',
                                  'long_name': 'The Doors'}
         assert self.testInst.meta['help', 'long_name'] == 'The Doors'
+        assert self.testInst.meta['help', 'axis'] == 'help'
+        assert self.testInst.meta['help', 'label'] == 'help'
+        assert self.testInst.meta['help', 'notes'] == ''
+        assert np.isnan(self.testInst.meta['help', 'fill'])
+        assert np.isnan(self.testInst.meta['help', 'value_min'])
+        assert np.isnan(self.testInst.meta['help', 'value_max'])
+        assert self.testInst.meta['help', 'units'] == 'V'
+        assert self.testInst.meta['help', 'desc'] == ''
+        assert self.testInst.meta['help', 'scale'] == 'linear'
+
+    def test_inst_data_assign_meta_then_data(self):
+        self.testInst.load(2009,1)
+        self.testInst['help'] = {'data':self.testInst['mlt'],
+                                 'units': 'V',
+                                 'long_name': 'The Doors'}
+        self.testInst['help'] = self.testInst['mlt']
+        assert self.testInst.meta['help', 'long_name'] == 'The Doors'
+        assert self.testInst.meta['help', 'axis'] == 'help'
+        assert self.testInst.meta['help', 'label'] == 'help'
+        assert self.testInst.meta['help', 'notes'] == ''
+        assert np.isnan(self.testInst.meta['help', 'fill'])
+        assert np.isnan(self.testInst.meta['help', 'value_min'])
+        assert np.isnan(self.testInst.meta['help', 'value_max'])
+        assert self.testInst.meta['help', 'units'] == 'V'
+        assert self.testInst.meta['help', 'desc'] == ''
+        assert self.testInst.meta['help', 'scale'] == 'linear'
 
     def test_inst_ho_data_assign_no_meta_default(self):
         self.testInst.load(2009,1)
@@ -39,6 +75,8 @@ class TestBasics():
                                columns=['dummy_frame1', 'dummy_frame2'])
         self.testInst['help'] = [frame]*len(self.testInst.data.index)
                                  
+        assert 'dummy_frame1' in self.testInst.meta.ho_data['help']
+        assert 'dummy_frame2' in self.testInst.meta.ho_data['help']
         assert 'dummy_frame1' in self.testInst.meta['help']['children']
         assert 'dummy_frame2' in self.testInst.meta['help']['children']
         assert self.testInst.meta['help']['children'].has_attr('units')
@@ -54,6 +92,8 @@ class TestBasics():
                                  'long_name': 'The Doors'}
 
         assert self.testInst.meta['help', 'long_name'] == 'The Doors'
+        assert 'dummy_frame1' in self.testInst.meta.ho_data['help']
+        assert 'dummy_frame2' in self.testInst.meta.ho_data['help']
         assert 'dummy_frame1' in self.testInst.meta['help']['children']
         assert 'dummy_frame2' in self.testInst.meta['help']['children']
         assert self.testInst.meta['help']['children'].has_attr('units')
@@ -73,6 +113,34 @@ class TestBasics():
                                  'meta': meta}
 
         assert self.testInst.meta['help', 'long_name'] == 'The Doors'
+        assert 'dummy_frame1' in self.testInst.meta.ho_data['help']
+        assert 'dummy_frame2' in self.testInst.meta.ho_data['help']
+        assert 'dummy_frame1' in self.testInst.meta['help']['children']
+        assert 'dummy_frame2' in self.testInst.meta['help']['children']
+        assert self.testInst.meta['help']['children'].has_attr('units')
+        assert self.testInst.meta['help']['children'].has_attr('desc')
+        assert self.testInst.meta['help']['children']['dummy_frame1', 'units'] == 'A'
+        assert self.testInst.meta['help']['children']['dummy_frame1', 'desc'] == ''
+        assert self.testInst.meta['help']['children']['dummy_frame2', 'desc'] == 'nothing'
+
+    def test_inst_ho_data_assign_meta_then_data(self):
+        self.testInst.load(2009,1)
+        frame = pds.DataFrame({'dummy_frame1':np.arange(10),
+                               'dummy_frame2':np.arange(10)},
+                               columns=['dummy_frame1', 'dummy_frame2'])
+        meta = pysat.Meta()
+        meta['dummy_frame1'] = {'units': 'A'}
+        meta['dummy_frame2'] = {'desc': 'nothing'}
+        print('Setting original data')
+        self.testInst['help'] = {'data':[frame]*len(self.testInst.data.index),
+                                 'units': 'V',
+                                 'long_name': 'The Doors',
+                                 'meta': meta}
+        self.testInst['help'] = [frame]*len(self.testInst.data.index)
+
+        assert self.testInst.meta['help', 'long_name'] == 'The Doors'
+        assert 'dummy_frame1' in self.testInst.meta.ho_data['help']
+        assert 'dummy_frame2' in self.testInst.meta.ho_data['help']
         assert 'dummy_frame1' in self.testInst.meta['help']['children']
         assert 'dummy_frame2' in self.testInst.meta['help']['children']
         assert self.testInst.meta['help']['children'].has_attr('units')
@@ -95,6 +163,8 @@ class TestBasics():
                                  'meta': meta}
 
         assert self.testInst.meta['help', 'long_name'] == 'The Doors'
+        assert 'dummy_frame1' in self.testInst.meta.ho_data['help']
+        assert 'dummy_frame2' in self.testInst.meta.ho_data['help']
         assert 'dummy_frame1' in self.testInst.meta['help']['children']
         assert 'dummy_frame2' in self.testInst.meta['help']['children']
         assert self.testInst.meta['help']['children'].has_attr('units')
@@ -103,6 +173,92 @@ class TestBasics():
         assert self.testInst.meta['help']['children']['dummy_frame1', 'desc'] == ''
         assert self.testInst.meta['help']['children']['dummy_frame2', 'desc'] == 'nothing'
         
+    def test_inst_assign_from_meta(self):
+        self.testInst.load(2009,1)
+        self.testInst['help'] = self.testInst['mlt']
+        self.testInst['help2'] = self.testInst['mlt']
+        self.testInst.meta['help2'] = self.testInst.meta['help']
+
+        assert self.testInst.meta['help2', 'long_name'] == 'help'
+        assert self.testInst.meta['help2', 'axis'] == 'help'
+        assert self.testInst.meta['help2', 'label'] == 'help'
+        assert self.testInst.meta['help2', 'notes'] == ''
+        assert np.isnan(self.testInst.meta['help2', 'fill'])
+        assert np.isnan(self.testInst.meta['help2', 'value_min'])
+        assert np.isnan(self.testInst.meta['help2', 'value_max'])
+        assert self.testInst.meta['help2', 'units'] == ''
+        assert self.testInst.meta['help2', 'desc'] == ''
+        assert self.testInst.meta['help2', 'scale'] == 'linear'
+        assert 'children' not in self.testInst.meta.data.columns
+        assert 'help2' not in self.testInst.meta.keys_nD()
+
+    def test_inst_assign_from_meta_w_ho(self):
+        self.testInst.load(2009,1)
+        frame = pds.DataFrame({'dummy_frame1':np.arange(10),
+                               'dummy_frame2':np.arange(10)},
+                               columns=['dummy_frame1', 'dummy_frame2'])
+        meta = pysat.Meta()
+        meta['dummy_frame1'] = {'units': 'A'}
+        meta['dummy_frame2'] = {'desc': 'nothing'}
+        self.testInst['help'] = {'data':[frame]*len(self.testInst.data.index),
+                                 'units': 'V',
+                                 'long_name': 'The Doors',
+                                 'meta': meta}
+        self.testInst['help2'] = self.testInst['help']
+        self.testInst.meta['help2'] = self.testInst.meta['help']
+        
+        assert self.testInst.meta['help'].children['dummy_frame1', 'units'] == 'A'
+        assert self.testInst.meta['help2', 'long_name'] == 'The Doors'
+        assert 'dummy_frame1' in self.testInst.meta.ho_data['help2']
+        assert 'dummy_frame2' in self.testInst.meta.ho_data['help2']
+        assert 'dummy_frame1' in self.testInst.meta['help2']['children']
+        assert 'dummy_frame2' in self.testInst.meta['help2']['children']
+        assert self.testInst.meta['help2']['children'].has_attr('units')
+        assert self.testInst.meta['help2']['children'].has_attr('desc')
+        assert self.testInst.meta['help2']['children']['dummy_frame1', 'desc'] == ''
+        assert self.testInst.meta['help2']['children']['dummy_frame2', 'desc'] == 'nothing'
+        assert 'children' not in self.testInst.meta.data.columns
+
+    def test_inst_assign_from_meta_w_ho_then_update(self):
+        self.testInst.load(2009,1)
+        frame = pds.DataFrame({'dummy_frame1':np.arange(10),
+                               'dummy_frame2':np.arange(10)},
+                               columns=['dummy_frame1', 'dummy_frame2'])
+        meta = pysat.Meta()
+        meta['dummy_frame1'] = {'units': 'A'}
+        meta['dummy_frame2'] = {'desc': 'nothing'}
+        self.testInst['help'] = {'data':[frame]*len(self.testInst.data.index),
+                                 'units': 'V',
+                                 'name': 'The Doors',
+                                 'meta': meta}
+        self.testInst['help2'] = self.testInst['help']
+        self.testInst.meta['help2'] = self.testInst.meta['help']
+        new_meta = self.testInst.meta['help2'].children
+        new_meta['dummy_frame1'] = {'units':'Amps',
+                                   'desc': 'something',
+                                   'label': 'John Wick',
+                                   'axis': 'Reeves',
+                                   }
+        self.testInst.meta['help2'] = new_meta
+        self.testInst.meta['help2'] = {'label': 'The Doors Return'}
+        
+        # print ('yoyo: ', self.testInst.meta['help']['children']['dummy_frame1', 'units'])
+        assert self.testInst.meta['help']['children']['dummy_frame1', 'units'] == 'A'        
+        assert self.testInst.meta['help2', 'name'] == 'The Doors'
+        assert self.testInst.meta['help2', 'label'] == 'The Doors Return'
+        assert 'dummy_frame1' in self.testInst.meta.ho_data['help2']
+        assert 'dummy_frame2' in self.testInst.meta.ho_data['help2']
+        assert 'dummy_frame1' in self.testInst.meta['help2']['children']
+        assert 'dummy_frame2' in self.testInst.meta['help2']['children']
+        assert self.testInst.meta['help2']['children'].has_attr('units')
+        assert self.testInst.meta['help2']['children'].has_attr('desc')
+        assert self.testInst.meta['help2']['children']['dummy_frame1', 'desc'] == 'something'
+        assert self.testInst.meta['help2']['children']['dummy_frame2', 'desc'] == 'nothing'
+        assert self.testInst.meta['help2']['children']['dummy_frame1', 'units'] == 'Amps'
+        assert self.testInst.meta['help2']['children']['dummy_frame1', 'label'] == 'John Wick'
+        assert self.testInst.meta['help2']['children']['dummy_frame1', 'axis'] == 'Reeves'
+        assert 'children' not in self.testInst.meta.data.columns
+
     def test_repr_call_runs(self):
         self.testInst.meta['hi'] = {'units':'yoyo', 'long_name':'hello'}
         print(self.testInst.meta)
@@ -121,13 +277,14 @@ class TestBasics():
         assert True
 
     def test_basic_pops(self):
+        
         self.meta['new1'] = {'units':'hey1', 'long_name':'crew', 
                              'value_min':0, 'value_max':1}
         self.meta['new2'] = {'units':'hey', 'long_name':'boo', 
                             'description':'boohoo', 'fill':1, 
                             'value_min':0, 'value_max':1}
         # create then assign higher order meta data
-        meta2 = pysat.Meta()
+        meta2 = pysat.Meta(name_label='long_name')
         meta2['new31'] = {'units':'hey3', 'long_name':'crew_brew', 'fill':1,
                           'value_min':0, 'value_max':1}
         self.meta['new3'] = meta2


### PR DESCRIPTION
Improves robustness when working with higher order data and Meta object.
Improved robustness of higher and lower metadata interactions when setting data via the Instrument object.
Corrected data access for higher order meta object via __getitem_.
Switched some __getitem__ data so that a copy is returned.
Added Meta tests.
Added check to test_instruments to limit testing of loading until a downloaded file is confirmed.
Removed redundant items in Instrument docstring.