### PR TITLE
Begin modernizing install / build/ test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,16 @@
 *~
 .DS_store
 
-# Python Repository Ignores as Recommended by github.com########################
+.mypy_cache/
+.pytest_cache/
+*.avi
+*.key
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*$py.class
 
 # C extensions
 *.so
@@ -46,6 +52,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.hypothesis/
 
 # Translations
 *.mo
@@ -53,6 +60,14 @@ coverage.xml
 
 # Django stuff:
 *.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
 docs/_build/
@@ -60,6 +75,26 @@ docs/_build/
 # PyBuilder
 target/
 
+# IPython Notebook
 .ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
 
 *.py#

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
+fast_finish: true
+
+os: 
+  - linux
+
 python:
-  - "2.7"
-  #- "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-sudo: false
+  - 2.7
+  - 3.5
+  - 3.6
 
 addons:
   apt:
@@ -15,9 +17,8 @@ addons:
 
 # Setup anaconda
 before_install:
-  #- apt-get update
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+  - if [[ $TRAVIS_OS_NAME == osx ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
@@ -29,22 +30,15 @@ before_install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose pandas statsmodels coverage netCDF4
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION atlas
 
-# command to install dependencies
 install:
-  # Coverage packages are on my binstar channel
-  # - conda install --yes -c dan_blanchard python-coveralls nose-cov
   - source activate test-environment
-  - pip install coveralls
-  # pysatCDF installed via setup.py requirement
-  # - pip install pysatCDF
-  - "python setup.py install"
-# command to run tests
-script: 
-  #- nosetests
-  - nosetests  --with-coverage --cover-package=pysat
-  #coverage run --source=pysat setup.py test
+  - pip install -e .[tests]
+
+script: pytest --cov
+
 after_success:
-  coveralls
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
+    coveralls;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q --yes conda
+  - conda update pip
   # Useful for debugging any issues with conda
   - conda info -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,10 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q --yes conda
-  - conda update pip
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION atlas
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION atlas 
 
 install:
   - source activate test-environment

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION atlas 
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION atlas numpy
 
 install:
   - source activate test-environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,32 @@
+[metadata]
+name = pysat
+url = https://github.com/rstoneback/pysat
+author = Russell Stoneback
+author_email = rstoneba@utdallas.edu
+description = Supports science data analysis across measurement platforms
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = BSD
+
+classifiers =
+  Development Status :: 4 - Beta
+
+  Intended Audience :: Science/Research
+  Topic :: Scientific/Engineering :: Astronomy
+  Topic :: Scientific/Engineering :: Physics
+  Topic :: Scientific/Engineering :: Atmospheric Science
+
+  License :: OSI Approved :: BSD License
+
+  Programming Language :: Python :: 2.7
+  Programming Language :: Python :: 3.5
+  Programming Language :: Python :: 3.6
+
+
+[options]
+include_package_data = True
+install_requires =
+  pandas
+
+[options.extras_require]
+tests = pysatCDF; nose; pytest; pytest-cov; coveralls; flake8; numpy; scipy; netCDF4; statsmodels; matplotlib

--- a/setup.py
+++ b/setup.py
@@ -3,86 +3,29 @@ See:
 https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
-
-# Always prefer setuptools over distutils
 from setuptools import setup
 # To use a consistent encoding
 from codecs import open
-from os import path
 import os
 
-here = path.abspath(path.dirname(__file__))
-with open(path.join(here, 'description.txt'), encoding='utf-8') as f:
-    long_description = f.read()
+here = os.path.abspath(os.path.dirname(__file__))
+
 version_filename = os.path.join('pysat', 'version.txt')
 with open(os.path.join(here, version_filename)) as version_file:
     version = version_file.read().strip()
 
-# change setup.py for readthedocs
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
-if on_rtd:
-    install_requires=['pandas', 'numpy'] 
-else:
-    install_requires=['pandas', 'numpy', 'pysatCDF']
-
 setup(
-    name='pysat',
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
     version=version,
     
-    description='Supports science data analysis across measurement platforms',    
-    long_description=long_description,
     # The project's main homepage.
     url='http://github.com/rstoneback/pysat',
 
-    # Author details
-    author='Russell Stoneback',
-    author_email='rstoneba@utdallas.edu',
-
-    
     package_data = {'pysat': ['pysat/version*.txt']},
-    include_package_data=True,
-    
-    # Choose your license
-    license='BSD',
-
-    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    classifiers=[
-        # How mature is this project? Common values are
-        #   3 - Alpha
-        #   4 - Beta
-        #   5 - Production/Stable
-        'Development Status :: 5 - Production/Stable',
-
-        # Indicate who your project is intended for
-        'Intended Audience :: Science/Research',
-        'Topic :: Scientific/Engineering :: Astronomy',
-        'Topic :: Scientific/Engineering :: Physics',
-        'Topic :: Scientific/Engineering :: Atmospheric Science',
-
-        # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: BSD License',
-
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-    ],
-
-    # What does your project relate to?
-    #keywords='sample setuptools development',
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=['pysat', 'pysat.instruments', 'pysat.ssnl'],
-
-    # List run-time dependencies here.  These will be installed by pip when
-    # your project is installed. For an analysis of "install_requires" vs pip's
-    # requirements files see:
-    # https://packaging.python.org/en/latest/requirements.html
-    install_requires = install_requires,
 )


### PR DESCRIPTION
Modernizing to use `setup.cfg` for most install settings. This is great for automation/templating and simpler than dumping everything in `setup.py`. `setup.cfg` is the modern way to do things.

Python 3.4 is dropped by `xarray` and soon by other major packages. 3.4 is an increasingly deprecated pain to support; 3.4 will be very difficult to support past year end 2018.

Future pull request will begin switch from `nose` to `pytest`.  In general test code will become shorter and simpler to do the same things via `@pytest` decorators. I use pytest extensively in my packages.

