### PR TITLE
Add uneven bins to median2D in ssnl.avg.py

### DIFF
--- a/pysat/ssnl/avg.py
+++ b/pysat/ssnl/avg.py
@@ -12,7 +12,7 @@ import pandas as pds
 import collections
 
 def median2D(const, bin1, label1, bin2, label2, data_label, 
-             returnData=False):
+             returnData=False, auto_bin=True):
     """Return a 2D average of data_label over a season and label1, label2.
 
     Parameters
@@ -46,8 +46,12 @@ def median2D(const, bin1, label1, bin2, label2, data_label,
 
     # create bins
     #// seems to create the boundaries used for sorting into bins
-    binx = np.linspace(bin1[0], bin1[1], bin1[2]+1)
-    biny = np.linspace(bin2[0], bin2[1], bin2[2]+1)
+    if auto_bin:
+        binx = np.linspace(bin1[0], bin1[1], bin1[2]+1)
+        biny = np.linspace(bin2[0], bin2[1], bin2[2]+1)
+    else:
+        binx=bin1
+        biny=bin2
 
     #// how many bins are used
     numx = len(binx)-1


### PR DESCRIPTION
The only change I'm suggesting is the added capability of making the bins for median2D capable of being uneven. 
The way I have structured this is that the user may input a sequence into bin1/2 that is taken as all of the bin edges, or they may specify the number of bins with bin1/2 and a range with range 1/2.
Perhaps instead of asking if the user has specified a range, it should ask if bin1/2 is a number or sequence.
Also will probably need some error handling for input type mismatches... if this change seems like something worth adding.

There are other changes in this fork, but I'm NOT suggesting changing median to nanmedian. It's something I like, but if introduced would have to be introduced as a flag so the user can choose and I haven't done this.