### PR TITLE
TIEGCM initial instrument support

### DIFF
--- a/docs/supported_instruments.rst
+++ b/docs/supported_instruments.rst
@@ -127,3 +127,9 @@ TIMED/SEE
 
 .. automodule:: pysat.instruments.timed_see
    :members: __doc__
+
+UCAR TIEGCM
+-----------
+
+.. automodule:: pysat.instruments.ucar_tiegcm
+   :members: __doc__

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -524,28 +524,48 @@ class Instrument(object):
                 return
             elif isinstance(key, basestring):
                 # assigning basic variable
-                if len(np.shape(in_data)) == 1:
+                
+                # if xarray input, take as is
+                if isinstance(in_data, xr.DataArray):
+                    self.data[key] = in_data
+                    
+                # ok, not an xarray input
+                # but if we have an iterable input, then we
+                # go through here
+                elif len(np.shape(in_data)) == 1:
+                    # looking at a 1D input here
                     if len(in_data) == len(self.index):
+                        # 1D input has the correct length for storage along 'time'
                         self.data[key] = ('time', in_data)
                     elif len(in_data) == 1:
+                        # only provided a single number in iterable, make that the input
+                        # for all times
                         self.data[key] = ('time', [in_data[0]]*len(self.index))
                     elif len(in_data) == 0:
+                        # provided an empty iterable
+                        # make everything NaN
                         self.data[key] = ('time', [np.nan]*len(self.index))
+                # not an iterable input
                 elif len(np.shape(in_data)) == 0:
+                    # not given an iterable at all, single number
+                    # make that number the input for all times
                     self.data[key] = ('time', [in_data]*len(self.index))
+                    
                 else:
-                    try:
+                    # multidimensional input that is not an xarray
+                    # user needs to provide what is required
+                    if isinstance(in_data, tuple):
                         self.data[key] = in_data
-                    except:
-                        # multidimensional input
-                        # user needs to provide what is required
-                        if isinstance(in_data, tuple):
-                            self.data[key] = in_data
-                        else:
-                            raise ValueError('Must provide dimensions for xarray multidimensional data using input tuple.')
+                    else:
+                        raise ValueError('Must provide dimensions for xarray multidimensional data using input tuple.')
+                        
             elif hasattr(key, '__iter__'):
+                # multiple input strings (keys) are provided, but not in tuple form
+                # recurse back into this function, setting each
+                # input individually
                 for keyname in key:
                     self.data[keyname] = in_data[keyname]
+                    
             # attach metadata            
             self.meta[key] = new
                         

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -534,12 +534,15 @@ class Instrument(object):
                 elif len(np.shape(in_data)) == 0:
                     self.data[key] = ('time', [in_data]*len(self.index))
                 else:
-                    # multidimensional input
-                    # user needs to provide what is required
-                    if isinstance(in_data, tuple):
+                    try:
                         self.data[key] = in_data
-                    else:
-                        raise ValueError('Must provide dimensions for xarray multidimensional data using input tuple.')
+                    except:
+                        # multidimensional input
+                        # user needs to provide what is required
+                        if isinstance(in_data, tuple):
+                            self.data[key] = in_data
+                        else:
+                            raise ValueError('Must provide dimensions for xarray multidimensional data using input tuple.')
             elif hasattr(key, '__iter__'):
                 for keyname in key:
                     self.data[keyname] = in_data[keyname]

--- a/pysat/instruments/ucar_tiegcm.py
+++ b/pysat/instruments/ucar_tiegcm.py
@@ -86,10 +86,10 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     fnames : array-like
         iterable of filename strings, full path, to data files to be loaded.
         This input is nominally provided by pysat itself.
-    tag : string (None)
+    tag : string ('')
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string (None)
+    sat_id : string ('')
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     **kwargs : extra keywords
@@ -156,10 +156,10 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     Parameters
     ----------
-    tag : string (None)
+    tag : string ('')
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string (None)
+    sat_id : string ('')
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     data_path : string (None)

--- a/pysat/instruments/ucar_tiegcm.py
+++ b/pysat/instruments/ucar_tiegcm.py
@@ -15,40 +15,67 @@ tag : string
    
 Note
 ----
+::
 
     Loads into xarray format.
     
 """
 
+# python 2/3 comptability
 from __future__ import print_function
 from __future__ import absolute_import
 
-import os
-
-import pandas as pds
 import xarray as xr
-import numpy as np
 import pysat
 
+# the platform and name strings associated with this instrument
+# need to be defined at the top level
+# these attributes will be copied over to the Instrument object by pysat
+# the strings used here should also be used to name this file
+# platform_name.py
 platform = 'ucar'
 name = 'tiegcm'
 
+# dictionary of data 'tags' and corresponding description
+tags = {'':'Level-2 IVM Files', # this is the default
+        'L1': 'Level-1 IVM Files',
+        'L0': 'Level-0 IVM Files'}
+# dictionary of satellite IDs, list of corresponding tags for each sat_ids
+# example
+# sat_ids = {'a':['L1', 'L0'], 'b':['L1', 'L2'], 'c':['L1', 'L3']}
+sat_ids = {'':['']}
+# good day to download test data for. Downloads aren't currently supported!
+# format is outer dictionary has sat_id as the key
+# each sat_id has a dictionary of test dates keyed by tag string
+test_dates = {'':{'':pysat.datetime(2019,1,1)}}
+
 # specify using xarray (not using pandas)
 pandas_format = False
+
 
 def init(self):
     """Initializes the Instrument object with instrument specific values.
     
     Runs once upon instantiation.
     
+    Parameters
+    ----------
+    self : pysat.Instrument
+        This object
+
+    Returns
+    --------
+    Void : (NoneType)
+        Object modified in place.
+    
+    
     """
     
     print ("Mission acknowledgements and data restrictions will be printed here when available.")
-    
-    pass
+    return
 
 
-def load(fnames, tag=None, sat_id=None):
+def load(fnames, tag=None, sat_id=None, **kwargs):
     """Loads TIEGCM data using xarray.
     
     This routine is called as needed by pysat. It is not intended
@@ -59,10 +86,10 @@ def load(fnames, tag=None, sat_id=None):
     fnames : array-like
         iterable of filename strings, full path, to data files to be loaded.
         This input is nominally provided by pysat itself.
-    tag : string
+    tag : string (None)
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string
+    sat_id : string (None)
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     **kwargs : extra keywords
@@ -88,12 +115,13 @@ def load(fnames, tag=None, sat_id=None):
         inst.load(2019,1)
     
     """
-
+    
+    # load data
     data = xr.open_dataset(fnames[0])
-    meta = pysat.Meta()
     # move attributes to the Meta object
     # these attributes will be trasnferred to the Instrument object
     # automatically by pysat
+    meta = pysat.Meta()
     for attr in data.attrs:
         setattr(meta, attr[0], attr[1])
     data.attrs = []
@@ -103,7 +131,7 @@ def load(fnames, tag=None, sat_id=None):
         attrs = data.variables[key].attrs
         meta[key] = attrs
 
-    # move misc parameters
+    # move misc parameters from xarray to the Instrument object via Meta
     # doing this after the meta ensures all metadata is still kept
     # even for moved variables
     meta.p0 = data['p0']
@@ -111,7 +139,7 @@ def load(fnames, tag=None, sat_id=None):
     meta.grav = data['grav']
     meta.mag = data['mag']
     meta.timestep = data['timestep']
-    # remove from xarray
+    # remove these variables from xarray
     data = data.drop(['p0', 'p0_model', 'grav', 'mag', 'timestep'])
             
     return data, meta
@@ -120,20 +148,21 @@ def load(fnames, tag=None, sat_id=None):
 def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     """Produce a list of files corresponding to UCAR TIEGCM.
 
-    This routine is invoked by pysat and is not intended for direct use by the end user.
+    This routine is invoked by pysat and is not intended for direct 
+    use by the end user. Arguments are provided by pysat.
     
     Multiple data levels may be supported via the 'tag' input string.
     Currently defaults to level-2 data, or L2 in the filename.
 
     Parameters
     ----------
-    tag : string ('')
+    tag : string (None)
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string ('')
+    sat_id : string (None)
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    data_path : string
+    data_path : string (None)
         Full path to directory containing files to be loaded. This
         is provided by pysat. The user may specify their own data path
         at Instrument instantiation and it will appear here.
@@ -161,11 +190,43 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     the returned files are up to pysat specifications.
     
     """
-    
-    return pysat.Files.from_os(data_path=data_path, 
-                                format_str='tiegcm_icon_merg2.0_totTgcm.s_{day:03d}_{year:4d}.nc')
+    format_str = 'tiegcm_icon_merg2.0_totTgcm.s_{day:03d}_{year:4d}.nc'
+    return pysat.Files.from_os(data_path=data_path, format_str=format_str)
 
-def download(date_array, tag, sat_id, data_path=None, user=None, password=None):
+def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
+             **kwargs):
+    """Placeholder for UCAR TIEGCM downloads. Doesn't do anything.
+    
+    This routine is invoked by pysat and is not intended for direct use by the end user.
+    
+    Parameters
+    ----------
+    date_array : array-like
+        list of datetimes to download data for. The sequence of dates need not be contiguous.
+    tag : string ('')
+        Tag identifier used for particular dataset. This input is provided by pysat.
+    sat_id : string  ('')
+        Satellite ID string identifier used for particular dataset. This input is provided by pysat.
+    data_path : string (None)
+        Path to directory to download data to.
+    user : string (None)
+        User string input used for download. Provided by user and passed via pysat. If an account
+        is required for dowloads this routine here must error if user not supplied.
+    password : string (None)
+        Password for data download.
+    **kwargs : dict
+        Additional keywords supplied by user when invoking the download
+        routine attached to a pysat.Instrument object are passed to this
+        routine via kwargs.
+        
+    Returns
+    --------
+    Void : (NoneType)
+        Downloads data to disk.
+    
+    
+    """
+    
     print ('Not implemented.')
-    pass
+    return
 

--- a/pysat/instruments/ucar_tiegcm.py
+++ b/pysat/instruments/ucar_tiegcm.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+"""
+Supports loading data from files generated using TIEGCM 
+(Thermosphere Ionosphere Electrodynamics General Circulation Model) model.
+TIEGCM file is a netCDF file with multiple dimensions for some variables.
+
+Parameters
+----------
+platform : string
+    'ucar'
+name : string
+    'tiegcm'
+tag : string
+    None supported
+   
+"""
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+import os
+
+import pandas as pds
+import xarray as xr
+import numpy as np
+import pysat
+
+platform = 'ucar'
+name = 'tiegcm'
+
+pandas_format = False
+
+def init(self):
+    """Initializes the Instrument object with instrument specific values.
+    
+    Runs once upon instantiation.
+    
+    """
+    
+    print ("Mission acknowledgements and data restrictions will be printed here when available.")
+    
+    pass
+
+
+def load(fnames, tag=None, sat_id=None):
+    """Loads TIEGCM data using xarray.
+    
+    This routine is called as needed by pysat. It is not intended
+    for direct user interaction.
+    
+    Parameters
+    ----------
+    fnames : array-like
+        iterable of filename strings, full path, to data files to be loaded.
+        This input is nominally provided by pysat itself.
+    tag : string
+        tag name used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    sat_id : string
+        Satellite ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    **kwargs : extra keywords
+        Passthrough for additional keyword arguments specified when 
+        instantiating an Instrument object. These additional keywords
+        are passed through to this routine by pysat.
+    
+    Returns
+    -------
+    data, metadata
+        Data and Metadata are formatted for pysat. Data is a pandas 
+        DataFrame while metadata is a pysat.Meta instance.
+        
+    Note
+    ----
+    Any additional keyword arguments passed to pysat.Instrument
+    upon instantiation are passed along to this routine and through
+    to the load_netcdf4 call.
+    
+    Examples
+    --------
+    ::
+        inst = pysat.Instrument('ucar', 'tiegcm')
+        inst.load(2019,1)
+    
+    """
+
+    data = xr.open_dataset(fnames[0])
+    meta = pysat.Meta()
+    return data, meta
+
+
+def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
+    """Produce a list of files corresponding to UCAR TIEGCM.
+
+    This routine is invoked by pysat and is not intended for direct use by the end user.
+    
+    Multiple data levels may be supported via the 'tag' input string.
+    Currently defaults to level-2 data, or L2 in the filename.
+
+    Parameters
+    ----------
+    tag : string ('')
+        tag name used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    sat_id : string ('')
+        Satellite ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    data_path : string
+        Full path to directory containing files to be loaded. This
+        is provided by pysat. The user may specify their own data path
+        at Instrument instantiation and it will appear here.
+    format_str : string (None)
+        String template used to parse the datasets filenames. If a user
+        supplies a template string at Instrument instantiation
+        then it will appear here, otherwise defaults to None.
+    
+    Returns
+    -------
+    pandas.Series
+        Series of filename strings, including the path, indexed by datetime.
+    
+    Examples
+    --------
+    ::
+        If a filename is SPORT_L2_IVM_2019-01-01_v01r0000.NC then the template
+        is 'SPORT_L2_IVM_{year:04d}-{month:02d}-{day:02d}_v{version:02d}r{revision:04d}.NC'
+    
+    Note
+    ----
+    The returned Series should not have any duplicate datetimes. If there are
+    multiple versions of a file the most recent version should be kept and the rest
+    discarded. This routine uses the pysat.Files.from_os constructor, thus
+    the returned files are up to pysat specifications.
+    
+    """
+    
+    return pysat.Files.from_os(data_path=data_path, 
+                                format_str='tiegcm_icon_merg2.0_totTgcm.s_{day:03d}_{year:4d}.nc')
+
+def download(date_array, tag, sat_id, data_path=None, user=None, password=None):
+    print ('Not implemented.')
+    pass
+


### PR DESCRIPTION
Includes Instrument support for TIEGCM files from UCAR. All variables loaded into .data include 'time' as a dimension. Attributes and other small variables are attached to the Instrument object itself, per pysat design. I should check if that is documented....

I added TIEGCM to the supported instrument documentation.

I modified data setting to give xarray a chance at understanding multidimensional data before I do anything else.

I can't add models label for some reason... perhaps because it isn't my project.
