### PR TITLE
Added template instruments, related to Issues #94

### DIFF
--- a/docs/supported_instruments.rst
+++ b/docs/supported_instruments.rst
@@ -1,4 +1,30 @@
 
+Instrument Templates
+====================
+
+General Instrument
+------------------
+
+.. automodule:: pysat.instruments.template_instrument
+   :members: __doc__, init, default, load, list_files, download, clean
+
+NASA CDAWeb Instrument
+----------------------
+
+.. automodule:: pysat.instruments.template_cdaweb_instrument
+   :members: __doc__, init, default, load, list_files, download, clean
+
+
+General Data Source Methods
+===========================
+
+NASA CDAWeb
+-----------
+
+.. automodule:: pysat.instruments.nasa_cdaweb_methods
+   :members: __doc__, init, load, list_files, download
+
+
 Supported Instruments
 =====================
 
@@ -78,12 +104,6 @@ netCDF Pandas
 -------------
 
 .. automodule:: pysat.instruments.netcdf_pandas
-   :members: __doc__, init, load, list_files, download
-
-NASA CDAWeb
------------
-
-.. automodule:: pysat.instruments.nasa_cdaweb_methods
    :members: __doc__, init, load, list_files, download
 
 OMNI

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -56,7 +56,7 @@ load = cdw.load
 basic_tag = {'dir':'/pub/data/cnofs/cindi/ivm_500ms_cdf',
             'remote_fname':'{year:4d}/'+ivm_fname,
             'local_fname':ivm_fname}
-supported_tags = {'':basic_tag}
+supported_tags = {'':{'':basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 
 

--- a/pysat/instruments/cnofs_plp.py
+++ b/pysat/instruments/cnofs_plp.py
@@ -52,7 +52,7 @@ load = cdw.load
 basic_tag = {'dir':'/pub/data/cnofs/plp/plasma_1sec',
             'remote_fname':'{year:4d}/'+fname,
             'local_fname':fname}
-supported_tags = {'':basic_tag}
+supported_tags = {'':{'':basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 
 

--- a/pysat/instruments/cnofs_vefi.py
+++ b/pysat/instruments/cnofs_vefi.py
@@ -56,7 +56,7 @@ load = cdw.load
 basic_tag = {'dir':'/pub/data/cnofs/vefi/bfield_1sec',
             'remote_fname':'{year:4d}/'+fname,
             'local_fname':fname}
-supported_tags = {'dc_b':basic_tag}
+supported_tags = {'':{'dc_b':basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 
                     

--- a/pysat/instruments/iss_fpmu.py
+++ b/pysat/instruments/iss_fpmu.py
@@ -52,7 +52,7 @@ load = cdw.load
 basic_tag = {'dir':'/pub/data/international_space_station_iss/sp_fpmu',
             'remote_fname':'{year:4d}/'+fname,
             'local_fname':fname}
-supported_tags = {'':basic_tag}
+supported_tags = {'':{'':basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 
 

--- a/pysat/instruments/nasa_cdaweb_methods.py
+++ b/pysat/instruments/nasa_cdaweb_methods.py
@@ -222,7 +222,7 @@ def download(supported_tags, date_array, tag, sat_id,
     ftp.login()               
     
     try:
-        ftp_dict = supported_tags[tag]
+        ftp_dict = supported_tags[sat_id][tag]
     except KeyError:
         raise ValueError('Tag name unknown.')
         

--- a/pysat/instruments/rocsat1_ivm.py
+++ b/pysat/instruments/rocsat1_ivm.py
@@ -56,7 +56,7 @@ load = cdw.load
 basic_tag = {'dir':'/pub/data/rocsat/ipei',
             'remote_fname':'{year:4d}/'+fname,
             'local_fname':fname}
-supported_tags = {'':basic_tag}
+supported_tags = {'':{'':basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
                 
                     

--- a/pysat/instruments/template_cdaweb_instrument.py
+++ b/pysat/instruments/template_cdaweb_instrument.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """This is a template for a pysat.Instrument support file that
-utilizes CDAWeb methods. Modify this file as needed when adding a 
+utilizes CDAWeb methods. Copy and modify this file as needed when adding a 
 new Instrument to pysat.
 
 This is a good area to introduce the instrument, provide background

--- a/pysat/instruments/template_cdaweb_instrument.py
+++ b/pysat/instruments/template_cdaweb_instrument.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""This is a template for a pysat.Instrument support file that
+utilizes CDAWeb methods. Modify this file as needed when adding a 
+new Instrument to pysat.
+
+This is a good area to introduce the instrument, provide background
+on the mission, operations, instrumenation, and measurements.
+
+Also a good place to provide contact information. This text will
+be included in the pysat API documentation.
+
+Parameters
+----------
+platform : string
+    *List platform string here*
+name : string
+    *List name string here*
+sat_id : string
+    *List supported sat_ids here*
+tag : string
+    *List supported tag strings here*
+
+Note
+----
+::
+
+    Notes
+    
+Warnings
+--------
+
+
+Authors
+-------   
+     
+"""
+
+from __future__ import print_function
+from __future__ import absolute_import
+
+import pandas as pds
+import numpy as np
+import pysat
+import sys
+import functools
+
+# CDAWeb methods prewritten for pysat
+from . import nasa_cdaweb_methods as cdw
+
+# the platform and name strings associated with this instrument
+# need to be defined at the top level
+# these attributes will be copied over to the Instrument object by pysat
+# the strings used here should also be used to name this file
+# platform_name.py
+platform = ''
+name = ''
+
+# dictionary of data 'tags' and corresponding description
+tags = {'':'description 1', # this is the default
+        'tag_string': 'description 2'}
+
+# Let pysat know if there are multiple satellite platforms supported
+# by these routines        
+# define a dictionary keyed by satellite ID, each with a list of 
+# corresponding tags 
+# sat_ids = {'a':['L1', 'L0'], 'b':['L1', 'L2'], 'c':['L1', 'L3']}
+sat_ids = {'':['']}
+
+# Define good days to download data for when pysat undergoes testing.
+# format is outer dictionary has sat_id as the key
+# each sat_id has a dictionary of test dates keyed by tag string
+# test_dates = {'a':{'L0':pysat.datetime(2019,1,1),
+#                    'L1':pysat.datetime(2019,1,2)},
+#               'b':{'L1':pysat.datetime(2019,3,1),
+#                    'L2':pysat.datetime(2019,11,23),}}
+test_dates = {'':{'':pysat.datetime(2019,1,1)}}
+
+# Additional information needs to be defined
+# to support the CDAWeb list files routine
+# We need to define a filename format string for every 
+# supported combination of sat_id and tag string
+# fname1 = 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
+# fname2 = 'cnofs_vefi_acfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
+# supported_tags = {'sat1':{'tag1':fname1},
+#                   'sat2':{'tag2':fname2}}
+# you can use format keywords year, month, day, hour, min, sec, 
+# version and revision
+# see code docstring for latest
+fname = 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
+supported_tags = {'':{'':fname}}
+# use the CDAWeb methods list files routine
+# the command below presets some of the methods inputs, leaving
+# those provided by pysat available when invoked
+list_files = functools.partial(cdw.list_files, 
+                               supported_tags=supported_tags)
+
+#                              
+# support load routine
+#
+# use the default CDAWeb method
+# no other information needs to be supplied here
+# pysatCDF is used to load data
+load = cdw.load
+
+#
+# support download routine
+#
+# to use the default CDAWeb method
+# we need to provide additional information
+# directory location on CDAWeb ftp server
+# formatting template for filenames on CDAWeb
+# formatting template for files saved to the local disk
+# a dictionary needs to be created for each sat_id and tag
+# combination along with the file format template
+# outer dict keyed by sat_id, inner dict keyed by tag
+basic_tag = {'dir':'/pub/data/cnofs/vefi/bfield_1sec',
+            'remote_fname':'{year:4d}/'+fname,
+            'local_fname':fname}
+supported_tags = {'':{'':basic_tag}}
+download = functools.partial(cdw.download, supported_tags)
+
+   
+# code should be defined below as needed                 
+def clean(inst):
+    """Routine to return PLATFORM/NAME data cleaned to the specified level
+
+    Cleaning level is specified in inst.clean_level and pysat
+    will accept user input for several strings. The clean_level is
+    specified at instantiation of the Instrument object.
+    
+    'clean' All parameters should be good, suitable for statistical and
+            case studies
+    'dusty' All paramers should generally be good though same may
+            not be great
+    'dirty' There are data areas that have issues, data should be used
+            with caution
+    'none'  No cleaning applied, routine not called in this case.
+    
+
+    Parameters
+    -----------
+    inst : (pysat.Instrument)
+        Instrument class object, whose attribute clean_level is used to return
+        the desired level of data selectivity.
+
+    Returns
+    --------
+    Void : (NoneType)
+        data in inst is modified in-place.
+
+    Notes
+    -----
+
+    """
+
+    return

--- a/pysat/instruments/template_cdaweb_instrument.py
+++ b/pysat/instruments/template_cdaweb_instrument.py
@@ -119,7 +119,28 @@ basic_tag = {'dir':'/pub/data/cnofs/vefi/bfield_1sec',
 supported_tags = {'':{'':basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 
-   
+# code should be defined below as needed  
+def default(self):
+    """Default customization function.
+    
+    This routine is automatically applied to the Instrument object
+    on every load by the pysat nanokernel (first in queue). 
+    
+    Parameters
+    ----------
+    self : pysat.Instrument
+        This object
+
+    Returns
+    --------
+    Void : (NoneType)
+        Object modified in place.
+    
+    
+    """
+    
+    return
+
 # code should be defined below as needed                 
 def clean(inst):
     """Routine to return PLATFORM/NAME data cleaned to the specified level

--- a/pysat/instruments/template_instrument.py
+++ b/pysat/instruments/template_instrument.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+"""
+Supports loading data from files generated using TIEGCM 
+(Thermosphere Ionosphere Electrodynamics General Circulation Model) model.
+TIEGCM file is a netCDF file with multiple dimensions for some variables.
+
+Parameters
+----------
+platform : string
+    'ucar'
+name : string
+    'tiegcm'
+tag : string
+    None supported
+   
+Note
+----
+::
+
+    Loads into xarray format.
+    
+"""
+
+# python 2/3 comptability
+from __future__ import print_function
+from __future__ import absolute_import
+
+import xarray as xr
+import pysat
+
+# the platform and name strings associated with this instrument
+# need to be defined at the top level
+# these attributes will be copied over to the Instrument object by pysat
+# the strings used here should also be used to name this file
+# platform_name.py
+platform = 'ucar'
+name = 'tiegcm'
+
+# dictionary of data 'tags' and corresponding description
+tags = {'':'Level-2 IVM Files', # this is the default
+        'L1': 'Level-1 IVM Files',
+        'L0': 'Level-0 IVM Files'}
+# dictionary of satellite IDs, list of corresponding tags for each sat_ids
+# example
+# sat_ids = {'a':['L1', 'L0'], 'b':['L1', 'L2'], 'c':['L1', 'L3']}
+sat_ids = {'':['']}
+# good day to download test data for. Downloads aren't currently supported!
+# format is outer dictionary has sat_id as the key
+# each sat_id has a dictionary of test dates keyed by tag string
+test_dates = {'':{'':pysat.datetime(2019,1,1)}}
+
+# specify using xarray (not using pandas)
+pandas_format = False
+
+
+def init(self):
+    """Initializes the Instrument object with instrument specific values.
+    
+    Runs once upon instantiation.
+    
+    Parameters
+    ----------
+    self : pysat.Instrument
+        This object
+
+    Returns
+    --------
+    Void : (NoneType)
+        Object modified in place.
+    
+    
+    """
+    
+    print ("Mission acknowledgements and data restrictions will be printed here when available.")
+    return
+
+
+def load(fnames, tag=None, sat_id=None, **kwargs):
+    """Loads TIEGCM data using xarray.
+    
+    This routine is called as needed by pysat. It is not intended
+    for direct user interaction.
+    
+    Parameters
+    ----------
+    fnames : array-like
+        iterable of filename strings, full path, to data files to be loaded.
+        This input is nominally provided by pysat itself.
+    tag : string (None)
+        tag name used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    sat_id : string (None)
+        Satellite ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    **kwargs : extra keywords
+        Passthrough for additional keyword arguments specified when 
+        instantiating an Instrument object. These additional keywords
+        are passed through to this routine by pysat.
+    
+    Returns
+    -------
+    data, metadata
+        Data and Metadata are formatted for pysat. Data is an xarray 
+        DataSet while metadata is a pysat.Meta instance.
+        
+    Note
+    ----
+    Any additional keyword arguments passed to pysat.Instrument
+    upon instantiation are passed along to this routine.
+    
+    Examples
+    --------
+    ::
+        inst = pysat.Instrument('ucar', 'tiegcm')
+        inst.load(2019,1)
+    
+    """
+    
+    # load data
+    data = xr.open_dataset(fnames[0])
+    # move attributes to the Meta object
+    # these attributes will be trasnferred to the Instrument object
+    # automatically by pysat
+    meta = pysat.Meta()
+    for attr in data.attrs:
+        setattr(meta, attr[0], attr[1])
+    data.attrs = []
+        
+    # fill Meta object with variable information
+    for key in data.variables.keys():
+        attrs = data.variables[key].attrs
+        meta[key] = attrs
+
+    # move misc parameters from xarray to the Instrument object via Meta
+    # doing this after the meta ensures all metadata is still kept
+    # even for moved variables
+    meta.p0 = data['p0']
+    meta.p0_model = data['p0_model']
+    meta.grav = data['grav']
+    meta.mag = data['mag']
+    meta.timestep = data['timestep']
+    # remove these variables from xarray
+    data = data.drop(['p0', 'p0_model', 'grav', 'mag', 'timestep'])
+            
+    return data, meta
+
+
+def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
+    """Produce a list of files corresponding to UCAR TIEGCM.
+
+    This routine is invoked by pysat and is not intended for direct 
+    use by the end user. Arguments are provided by pysat.
+    
+    Multiple data levels may be supported via the 'tag' input string.
+    Currently defaults to level-2 data, or L2 in the filename.
+
+    Parameters
+    ----------
+    tag : string (None)
+        tag name used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    sat_id : string (None)
+        Satellite ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    data_path : string (None)
+        Full path to directory containing files to be loaded. This
+        is provided by pysat. The user may specify their own data path
+        at Instrument instantiation and it will appear here.
+    format_str : string (None)
+        String template used to parse the datasets filenames. If a user
+        supplies a template string at Instrument instantiation
+        then it will appear here, otherwise defaults to None.
+    
+    Returns
+    -------
+    pandas.Series
+        Series of filename strings, including the path, indexed by datetime.
+    
+    Examples
+    --------
+    ::
+        If a filename is SPORT_L2_IVM_2019-01-01_v01r0000.NC then the template
+        is 'SPORT_L2_IVM_{year:04d}-{month:02d}-{day:02d}_v{version:02d}r{revision:04d}.NC'
+    
+    Note
+    ----
+    The returned Series should not have any duplicate datetimes. If there are
+    multiple versions of a file the most recent version should be kept and the rest
+    discarded. This routine uses the pysat.Files.from_os constructor, thus
+    the returned files are up to pysat specifications.
+    
+    """
+    format_str = 'tiegcm_icon_merg2.0_totTgcm.s_{day:03d}_{year:4d}.nc'
+    return pysat.Files.from_os(data_path=data_path, format_str=format_str)
+
+def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
+             **kwargs):
+    """Placeholder for UCAR TIEGCM downloads. Doesn't do anything.
+    
+    This routine is invoked by pysat and is not intended for direct use by the end user.
+    
+    Parameters
+    ----------
+    date_array : array-like
+        list of datetimes to download data for. The sequence of dates need not be contiguous.
+    tag : string ('')
+        Tag identifier used for particular dataset. This input is provided by pysat.
+    sat_id : string  ('')
+        Satellite ID string identifier used for particular dataset. This input is provided by pysat.
+    data_path : string (None)
+        Path to directory to download data to.
+    user : string (None)
+        User string input used for download. Provided by user and passed via pysat. If an account
+        is required for dowloads this routine here must error if user not supplied.
+    password : string (None)
+        Password for data download.
+    **kwargs : dict
+        Additional keywords supplied by user when invoking the download
+        routine attached to a pysat.Instrument object are passed to this
+        routine via kwargs.
+        
+    Returns
+    --------
+    Void : (NoneType)
+        Downloads data to disk.
+    
+    
+    """
+    
+    print ('Not implemented.')
+    return
+

--- a/pysat/instruments/template_instrument.py
+++ b/pysat/instruments/template_instrument.py
@@ -100,6 +100,26 @@ def init(self):
     print ("Mission acknowledgements and data restrictions will be printed here when available.")
     return
 
+def default(self):
+    """Default customization function.
+    
+    This routine is automatically applied to the Instrument object
+    on every load by the pysat nanokernel (first in queue). 
+    
+    Parameters
+    ----------
+    self : pysat.Instrument
+        This object
+
+    Returns
+    --------
+    Void : (NoneType)
+        Object modified in place.
+    
+    
+    """
+    
+    return
 
 def load(fnames, tag=None, sat_id=None, **kwargs):
     """Loads PLATFORM data into (PANDAS/XARRAY).

--- a/pysat/instruments/template_instrument.py
+++ b/pysat/instruments/template_instrument.py
@@ -283,3 +283,37 @@ def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
     
     return
 
+# code should be defined below as needed                 
+def clean(inst):
+    """Routine to return PLATFORM/NAME data cleaned to the specified level
+
+    Cleaning level is specified in inst.clean_level and pysat
+    will accept user input for several strings. The clean_level is
+    specified at instantiation of the Instrument object.
+    
+    'clean' All parameters should be good, suitable for statistical and
+            case studies
+    'dusty' All paramers should generally be good though same may
+            not be great
+    'dirty' There are data areas that have issues, data should be used
+            with caution
+    'none'  No cleaning applied, routine not called in this case.
+    
+
+    Parameters
+    -----------
+    inst : (pysat.Instrument)
+        Instrument class object, whose attribute clean_level is used to return
+        the desired level of data selectivity.
+
+    Returns
+    --------
+    Void : (NoneType)
+        data in inst is modified in-place.
+
+    Notes
+    -----
+
+    """
+
+    return

--- a/pysat/instruments/template_instrument.py
+++ b/pysat/instruments/template_instrument.py
@@ -222,9 +222,6 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     This routine is invoked by pysat and is not intended for direct 
     use by the end user. Arguments are provided by pysat.
     
-    Multiple data levels may be supported via the 'tag' input string.
-    Multiple instruments via the sat_id string.
-
     Parameters
     ----------
     tag : string ('')
@@ -259,6 +256,10 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     multiple versions of a file the most recent version should be kept and the rest
     discarded. This routine uses the pysat.Files.from_os constructor, thus
     the returned files are up to pysat specifications.
+    
+    Multiple data levels may be supported via the 'tag' input string.
+    Multiple instruments via the sat_id string.
+
     
     """
     

--- a/pysat/instruments/timed_see.py
+++ b/pysat/instruments/timed_see.py
@@ -62,7 +62,7 @@ list_files = functools.partial(cdw.list_files,
 basic_tag = {'dir': '/pub/data/timed/see/data/level3a_cdf',
              'remote_fname': '{year:4d}/{month:02d}/'+fname,
              'local_fname': fname}
-supported_tags = {'': basic_tag}
+supported_tags = {'':{'': basic_tag}}
 download = functools.partial(cdw.download, supported_tags)
 
 # support load routine


### PR DESCRIPTION
Trying to make adding new instruments easier.

Added a template for a general instrument, includes code for both xarray and pandas.
Uses pysat functions for list_files.

Added a template for using NASA CDAWeb methods. I expanded the download routine to include support for both sat_id and tag. Previously it only included tag. I updated associated instrument modules using CDAWeb methods.

Updated the supported instruments documentation. Trying a new section just for templates.

There is overlap between the template_instrument and the pre-existing netcdf4_pandas method. There is some distinction, the netcdf4 instrument can actually be used to load files. The template instrument docstrings are a bit more to the point. Perhaps a better basis to start a new instrument. I actually forgot about netcdf4_pandas until after I wrote this new template.