### PR TITLE
cdaweb access through requests

### DIFF
--- a/pysat/instruments/__init__.py
+++ b/pysat/instruments/__init__.py
@@ -11,7 +11,7 @@ is contained within a subpackage of this set.
 __all__ = ['champ_star', 'cnofs_ivm', 'cnofs_plp', 'cnofs_vefi',
            'cosmic2013_gps', 'cosmic_gps', 'demeter_iap',
            'dmsp_ivm', 'icon_ivm', 'icon_euv', 'icon_fuv', 'icon_mighti',
-           'iss_fpmu',  'omni_hro', 'pysat_sgp4', 'rocsat1_ivm',
+           'iss_fpmu',  'jro_isr', 'omni_hro', 'pysat_sgp4', 'rocsat1_ivm',
            'sport_ivm', 'superdarn_grdex', 'supermag_magnetometer', 
            'sw_dst', 'sw_kp', 'sw_f107', 'timed_see',
            'ucar_tiegcm',]

--- a/pysat/instruments/jro_isr.py
+++ b/pysat/instruments/jro_isr.py
@@ -41,6 +41,7 @@ import pysat
 from . import madrigal_methods as mad_meth
 from . import nasa_cdaweb_methods as cdw
 
+
 platform = 'jro'
 name = 'isr'
 tags = {'drifts':'Drifts and wind', 'drifts_ave':'Averaged drifts',
@@ -93,7 +94,7 @@ load = functools.partial(mad_meth.load, xarray_coords=['gdalt'])
 # To ensure this function is always applied first, we set the filter
 # function as the default function for (JRO).
 # Default function is run first by the nanokernel on every load call.
-default = pysat.instruments.madrigal_methods.filter_data_single_date      
+default = mad_meth.filter_data_single_date      
 
 def init(self):
     """Initializes the Instrument object with values specific to JRO ISR

--- a/pysat/instruments/nasa_cdaweb_methods.py
+++ b/pysat/instruments/nasa_cdaweb_methods.py
@@ -60,8 +60,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
         list_files = functools.partial(nasa_cdaweb_methods.list_files,
                                        supported_tags=supported_tags)
 
-        ivm_fname = 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
-        supported_tags = {'':ivm_fname}
+        fname = 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+        supported_tags = {'':fname}
         list_files = functools.partial(cdw.list_files,
                                        supported_tags=supported_tags)
 

--- a/pysat/instruments/nasa_cdaweb_methods.py
+++ b/pysat/instruments/nasa_cdaweb_methods.py
@@ -198,7 +198,7 @@ def download(supported_tags, date_array, tag, sat_id,
         User password to be passed along to resource with relevant data.
         (default=None)
     fake_daily_files_from_monthly : bool
-        Some CDAWeb instrument data files are stored by month.This flag,
+        Some CDAWeb instrument data files are stored by month. This flag,
         when true, accomodates this reality with user feedback on a monthly
         time frame.
 
@@ -215,9 +215,9 @@ def download(supported_tags, date_array, tag, sat_id,
         rn = '{year:4d}/cnofs_vefi_bfield_1sec_{year:4d}{month:02d}{day:02d}_v05.cdf'
         ln = 'cnofs_vefi_bfield_1sec_{year:4d}{month:02d}{day:02d}_v05.cdf'
         dc_b_tag = {'dir':'/pub/data/cnofs/vefi/bfield_1sec',
-                    'remote_fname':rn,
-                    'local_fname':ln}
-        supported_tags = {'dc_b':dc_b_tag}
+                    'remote_fname': rn,
+                    'local_fname': ln}
+        supported_tags = {'dc_b': dc_b_tag}
 
         download = functools.partial(nasa_cdaweb_methods.download,
                                      supported_tags=supported_tags)
@@ -302,7 +302,7 @@ def list_remote_files(tag, sat_id,
         User password to be passed along to resource with relevant data.
         (default=None)
     fake_daily_files_from_monthly : bool
-        Some CDAWeb instrument data files are stored by month.This flag,
+        Some CDAWeb instrument data files are stored by month. This flag,
         when true, accomodates this reality with user feedback on a monthly
         time frame.
     two_digit_year_break : int
@@ -322,12 +322,12 @@ def list_remote_files(tag, sat_id,
     ::
 
         fname = 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
-        supported_tags = {'dc_b':fname}
+        supported_tags = {'dc_b': fname}
         list_files = functools.partial(nasa_cdaweb_methods.list_files,
                                        supported_tags=supported_tags)
 
-        ivm_fname = 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
-        supported_tags = {'':ivm_fname}
+        fname = 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+        supported_tags = {'': fname}
         list_files = functools.partial(cdw.list_files,
                                        supported_tags=supported_tags)
 

--- a/pysat/instruments/nasa_cdaweb_methods.py
+++ b/pysat/instruments/nasa_cdaweb_methods.py
@@ -86,7 +86,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
         return out
     else:
         estr = 'A directory must be passed to the loading routine for <Instrument Code>'
-        raise ValueError (estr)
+        raise ValueError(estr)
 
 def load(fnames, tag=None, sat_id=None,
          fake_daily_files_from_monthly=False,

--- a/pysat/instruments/nasa_cdaweb_methods.py
+++ b/pysat/instruments/nasa_cdaweb_methods.py
@@ -265,10 +265,6 @@ def download(supported_tags, date_array, tag, sat_id,
             else:
                 print('File not available for ' + date.strftime('%x'))
         except requests.exceptions.RequestException as exception:
-            # if exception[0][0:3] != '550':
-            # if str(exception.args[0]).split(" ", 1)[0] != '550':
-            #    raise
-            # else:
             print('File not available for ' + date.strftime('%x'))
 
 
@@ -360,14 +356,11 @@ def list_remote_files(tag, sat_id,
     # Find Subdirectories if needed
     dir_split = os.path.split(format_str)
     if (len(dir_split) == 2) & (len(dir_split[0]) != 0):
-        # try:
         links = soup.find_all('a', href=True)
         dirs = []
         for link in links:
             if link['href'].count('/') == 1:
                 dirs.append(link['href'])
-        # except:
-        #     raise
         # only want to keep file portion of the string
         format_str = dir_split[-1]
     elif len(dir_split) == 2:
@@ -381,12 +374,10 @@ def list_remote_files(tag, sat_id,
         sub_path = remote_url + '/' + direct
         sub_soup = BeautifulSoup(requests.get(sub_path).content, "lxml")
         sub_links = sub_soup.find_all('a', href=True)
-        # try:
         for slink in sub_links:
             if slink['href'].count('.cdf') == 1:
                 full_files.append(slink['href'])
-        # except:
-        #     raise
+
     # parse remote filenames to get date information
     if delimiter is None:
         stored = pysat._files.parse_fixed_width_filenames(full_files,

--- a/pysat/instruments/nasa_cdaweb_methods.py
+++ b/pysat/instruments/nasa_cdaweb_methods.py
@@ -360,7 +360,7 @@ def list_remote_files(tag, sat_id,
         dirs = []
         for link in links:
             if link['href'].count('/') == 1:
-                dirs.extend(link['href'])
+                dirs.append(link['href'])
         # except:
         #     raise
         # only want to keep file portion of the string
@@ -378,8 +378,8 @@ def list_remote_files(tag, sat_id,
         sub_links = sub_soup.find_all('a', href=True)
         # try:
         for slink in sub_links:
-            if slink['href'].count('cdf') == 1:
-                full_files.extend(slink['href'])
+            if slink['href'].count('.cdf') == 1:
+                full_files.append(slink['href'])
         # except:
         #     raise
     # parse remote filenames to get date information

--- a/pysat/instruments/nasa_cdaweb_methods.py
+++ b/pysat/instruments/nasa_cdaweb_methods.py
@@ -350,7 +350,7 @@ def list_remote_files(tag, sat_id,
     # get a listing of all files
     # determine if we need to walk directories
 
-    soup = BeautifulSoup(requests.get(remote_url).content)
+    soup = BeautifulSoup(requests.get(remote_url).content, "lxml")
 
     # Find Subdirectories if needed
     dir_split = os.path.split(format_str)
@@ -374,14 +374,14 @@ def list_remote_files(tag, sat_id,
     full_files = []
     for direct in dirs:
         sub_path = remote_url + '/' + direct
-        sub_soup = BeautifulSoup(requests.get(sub_path).content)
+        sub_soup = BeautifulSoup(requests.get(sub_path).content, "lxml")
         sub_links = sub_soup.find_all('a', href=True)
-        try:
-            for slink in sub_links:
-                if slink['href'].count('.cdf') == 1:
-                    full_files.extend(slink['href'])
-        except:
-            raise
+        # try:
+        for slink in sub_links:
+            if slink['href'].count('cdf') == 1:
+                full_files.extend(slink['href'])
+        # except:
+        #     raise
     # parse remote filenames to get date information
     if delimiter is None:
         stored = pysat._files.parse_fixed_width_filenames(full_files, format_str)

--- a/pysat/instruments/nasa_cdaweb_methods.py
+++ b/pysat/instruments/nasa_cdaweb_methods.py
@@ -384,8 +384,10 @@ def list_remote_files(tag, sat_id,
         #     raise
     # parse remote filenames to get date information
     if delimiter is None:
-        stored = pysat._files.parse_fixed_width_filenames(full_files, format_str)
+        stored = pysat._files.parse_fixed_width_filenames(full_files,
+                                                          format_str)
     else:
-        stored = pysat._files.parse_delimited_filenames(full_files, format_str, delimiter)
+        stored = pysat._files.parse_delimited_filenames(full_files,
+                                                        format_str, delimiter)
     # process the parsed filenames and return a properly formatted Series
     return pysat._files.process_parsed_filenames(stored, two_digit_year_break)

--- a/pysat/instruments/nasa_cdaweb_methods.py
+++ b/pysat/instruments/nasa_cdaweb_methods.py
@@ -185,6 +185,9 @@ def download(supported_tags, date_array, tag, sat_id,
         tag or None (default=None)
     sat_id : (str or NoneType)
         satellite id or None (default=None)
+    remote_site : (string or NoneType)
+        Remote site to download data from
+        (default='https://cdaweb.gsfc.nasa.gov')
     data_path : (string or NoneType)
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
@@ -284,12 +287,14 @@ def list_remote_files(tag, sat_id,
     Parameters
     -----------
     tag : (string or NoneType)
-        Denotes type of file to load.  Accepted types are <tag strings>. (default=None)
+        Denotes type of file to load.  Accepted types are <tag strings>.
+        (default=None)
     sat_id : (string or NoneType)
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    ftp_site : (string or NoneType)
-        FTP site to download data from (default='cdaweb.gsfc.nasa.gov')
+    remote_site : (string or NoneType)
+        Remote site to download data from
+        (default='https://cdaweb.gsfc.nasa.gov')
     supported_tags : dict
         dict of dicts. Keys are supported tag names for download. Value is
         a dict with 'dir', 'remote_fname', 'local_fname'. Inteded to be

--- a/pysat/instruments/nasa_cdaweb_methods.py
+++ b/pysat/instruments/nasa_cdaweb_methods.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Provides default routines for integrating NASA CDAWeb instruments into pysat.
 Adding new CDAWeb datasets should only require mininal user intervention.
- 
+
 """
 
 from __future__ import absolute_import, division, print_function
@@ -16,7 +16,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
                supported_tags=None, fake_daily_files_from_monthly=False,
                two_digit_year_break=None):
     """Return a Pandas Series of every file for chosen satellite data.
-    
+
     This routine is intended to be used by pysat instrument modules supporting
     a particular NASA CDAWeb dataset.
 
@@ -40,7 +40,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
         Some CDAWeb instrument data files are stored by month, interfering
         with pysat's functionality of loading by day. This flag, when true,
         appends daily dates to monthly files internally. These dates are
-        used by load routine in this module to provide data by day. 
+        used by load routine in this module to provide data by day.
 
     Returns
     --------
@@ -49,18 +49,18 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
 
     Examples
     --------
-    :: 
+    ::
 
         fname = 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
         supported_tags = {'dc_b':fname}
-        list_files = functools.partial(nasa_cdaweb_methods.list_files, 
+        list_files = functools.partial(nasa_cdaweb_methods.list_files,
                                        supported_tags=supported_tags)
 
         ivm_fname = 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
         supported_tags = {'':ivm_fname}
-        list_files = functools.partial(cdw.list_files, 
+        list_files = functools.partial(cdw.list_files,
                                        supported_tags=supported_tags)
-    
+
     """
 
     if data_path is not None:
@@ -69,26 +69,26 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
                     format_str = supported_tags[sat_id][tag]
                 except KeyError:
                     raise ValueError('Unknown tag')
-        out = pysat.Files.from_os(data_path=data_path, 
+        out = pysat.Files.from_os(data_path=data_path,
                                   format_str=format_str)
 
         if (not out.empty) and fake_daily_files_from_monthly:
             out.ix[out.index[-1] + pds.DateOffset(months=1) -
-                                   pds.DateOffset(days=1)] = out.iloc[-1]  
+                                   pds.DateOffset(days=1)] = out.iloc[-1]
             out = out.asfreq('D', 'pad')
-            out = out + '_' + out.index.strftime('%Y-%m-%d')  
+            out = out + '_' + out.index.strftime('%Y-%m-%d')
             return out
 
         return out
     else:
         estr = 'A directory must be passed to the loading routine for <Instrument Code>'
-        raise ValueError (estr)            
+        raise ValueError (estr)
 
-def load(fnames, tag=None, sat_id=None, 
+def load(fnames, tag=None, sat_id=None,
          fake_daily_files_from_monthly=False,
          flatten_twod=True):
     """Load NASA CDAWeb CDF files.
-    
+
     This routine is intended to be used by pysat instrument modules supporting
     a particular NASA CDAWeb dataset.
 
@@ -105,7 +105,7 @@ def load(fnames, tag=None, sat_id=None,
         with pysat's functionality of loading by day. This flag, when true,
         parses of daily dates to monthly files that were added internally
         by the list_files routine, when flagged. These dates are
-        used here to provide data by day. 
+        used here to provide data by day.
 
     Returns
     ---------
@@ -113,22 +113,22 @@ def load(fnames, tag=None, sat_id=None,
         Object containing satellite data
     meta : (pysat.Meta)
         Object containing metadata such as column names and units
-        
+
     Examples
     --------
     ::
-    
+
         # within the new instrument module, at the top level define
         # a new variable named load, and set it equal to this load method
         # code below taken from cnofs_ivm.py.
-        
+
         # support load routine
         # use the default CDAWeb method
         load = cdw.load
 
-        
+
     """
-    
+
     import pysatCDF
 
     if len(fnames) <= 0 :
@@ -137,10 +137,10 @@ def load(fnames, tag=None, sat_id=None,
         # going to use pysatCDF to load the CDF and format
         # data and metadata for pysat using some assumptions.
         # Depending upon your needs the resulting pandas DataFrame may
-        # need modification 
+        # need modification
         # currently only loads one file, which handles more situations via pysat
         # than you may initially think
-        
+
         if fake_daily_files_from_monthly:
             # parse out date from filename
             fname = fnames[0][0:-11]
@@ -150,25 +150,26 @@ def load(fnames, tag=None, sat_id=None,
                 data, meta = cdf.to_pysat(flatten_twod=flatten_twod)
                 # select data from monthly
                 data = data.ix[date:date+pds.DateOffset(days=1) - pds.DateOffset(microseconds=1),:]
-                return data, meta     
+                return data, meta
         else:
-            # basic data return 
-            with pysatCDF.CDF(fnames[0]) as cdf:     
+            # basic data return
+            with pysatCDF.CDF(fnames[0]) as cdf:
                 return cdf.to_pysat(flatten_twod=flatten_twod)
 
-def download(supported_tags, date_array, tag, sat_id, 
-             ftp_site='cdaweb.gsfc.nasa.gov', 
+
+def download(supported_tags, date_array, tag, sat_id,
+             remote_site='https://cdaweb.gsfc.nasa.gov',
              data_path=None, user=None, password=None,
              fake_daily_files_from_monthly=False):
     """Routine to download NASA CDAWeb CDF data.
-    
+
     This routine is intended to be used by pysat instrument modules supporting
     a particular NASA CDAWeb dataset.
 
     Parameters
     -----------
     supported_tags : dict
-        dict of dicts. Keys are supported tag names for download. Value is 
+        dict of dicts. Keys are supported tag names for download. Value is
         a dict with 'dir', 'remote_fname', 'local_fname'. Inteded to be
         pre-set with functools.partial then assigned to new instrument code.
     date_array : array_like
@@ -181,15 +182,15 @@ def download(supported_tags, date_array, tag, sat_id,
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
     user : (string or NoneType)
-        Username to be passed along to resource with relevant data.  
+        Username to be passed along to resource with relevant data.
         (default=None)
     password : (string or NoneType)
-        User password to be passed along to resource with relevant data.  
+        User password to be passed along to resource with relevant data.
         (default=None)
     fake_daily_files_from_monthly : bool
-        Some CDAWeb instrument data files are stored by month.This flag, 
+        Some CDAWeb instrument data files are stored by month.This flag,
         when true, accomodates this reality with user feedback on a monthly
-        time frame. 
+        time frame.
 
     Returns
     --------
@@ -198,8 +199,8 @@ def download(supported_tags, date_array, tag, sat_id,
 
     Examples
     --------
-    :: 
-    
+    ::
+
         # download support added to cnofs_vefi.py using code below
         rn = '{year:4d}/cnofs_vefi_bfield_1sec_{year:4d}{month:02d}{day:02d}_v05.cdf'
         ln = 'cnofs_vefi_bfield_1sec_{year:4d}{month:02d}{day:02d}_v05.cdf'
@@ -207,63 +208,55 @@ def download(supported_tags, date_array, tag, sat_id,
                     'remote_fname':rn,
                     'local_fname':ln}
         supported_tags = {'dc_b':dc_b_tag}
-    
-        download = functools.partial(nasa_cdaweb_methods.download, 
+
+        download = functools.partial(nasa_cdaweb_methods.download,
                                      supported_tags=supported_tags)
-    
+
     """
 
     import os
-    import ftplib
+    import requests
 
-    # connect to CDAWeb default port
-    ftp = ftplib.FTP(ftp_site) 
-    # user anonymous, passwd anonymous@
-    ftp.login()               
-    
     try:
-        ftp_dict = supported_tags[sat_id][tag]
+        inst_dict = supported_tags[sat_id][tag]
     except KeyError:
         raise ValueError('Tag name unknown.')
-        
+
     # path to relevant file on CDAWeb
-    ftp.cwd(ftp_dict['dir'])
-    
+    remote_url = remote_site + inst_dict['dir']
+
     # naming scheme for files on the CDAWeb server
-    remote_fname = ftp_dict['remote_fname']
-    
+    remote_fname = inst_dict['remote_fname']
+
     # naming scheme for local files, should be closely related
     # to CDAWeb scheme, though directory structures may be reduced
     # if desired
-    local_fname = ftp_dict['local_fname']
-    
-    for date in date_array:            
-        # format files for specific dates and download location
-        formatted_remote_fname = remote_fname.format(year=date.year, 
-                        month=date.month, day=date.day)
-        formatted_local_fname = local_fname.format(year=date.year, 
-                        month=date.month, day=date.day)
-        saved_local_fname = os.path.join(data_path,formatted_local_fname) 
+    local_fname = inst_dict['local_fname']
 
-        # perform download                  
+    for date in date_array:
+        # format files for specific dates and download location
+        formatted_remote_fname = remote_fname.format(year=date.year,
+                                                     month=date.month,
+                                                     day=date.day)
+        formatted_local_fname = local_fname.format(year=date.year,
+                                                   month=date.month,
+                                                   day=date.day)
+        saved_local_fname = os.path.join(data_path, formatted_local_fname)
+
+        # perform download
         try:
             print('Attempting to download file for '+date.strftime('%x'))
             sys.stdout.flush()
-            ftp.retrbinary('RETR '+formatted_remote_fname, open(saved_local_fname,'wb').write)
-            print('Finished.')
-        except ftplib.error_perm as exception:
-            # if exception[0][0:3] != '550':
-            if str(exception.args[0]).split(" ", 1)[0] != '550':
-                raise
+            remote_path = '/'.join((remote_url, formatted_remote_fname))
+            r = requests.get(remote_path)
+            if r.status_code != 404:
+                open(saved_local_fname, 'wb').write(r.content)
+                print('Finished.')
             else:
-                os.remove(saved_local_fname)
-                print('File not available for '+ date.strftime('%x'))
-    ftp.close()
-               
-                    
-                    
-                    
-                    
-                    
-
-
+                print('File not available for ' + date.strftime('%x'))
+        except requests.exceptions.RequestException as exception:
+            # if exception[0][0:3] != '550':
+            # if str(exception.args[0]).split(" ", 1)[0] != '550':
+            #    raise
+            # else:
+            print('File not available for ' + date.strftime('%x'))

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -89,7 +89,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     if format_str is None and data_path is not None:
         if (tag == '1min') | (tag == '5min'):
             min_fmt = ''.join(['omni_hro_', tag,
-                               '{year:4d}{month:02d}{day:02d}_v01.cdf'])
+                               '_{year:4d}{month:02d}{day:02d}_v01.cdf'])
             files = pysat.Files.from_os(data_path=data_path, format_str=min_fmt)
             # files are by month, just add date to monthly filename for
             # each day of the month. load routine will use date to select out

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -76,7 +76,7 @@ list_files = functools.partial(cdw.list_files,
 
 # support load routine
 # use the default CDAWeb method
-load = cdw.load
+load = functools.partial(cdw.load, fake_daily_files_from_monthly=True)
 
 # support download routine
 # use the default CDAWeb method

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -88,7 +88,6 @@ basic_tag5 = {'dir': '/pub/data/omni/omni_cdaweb/hro_5min',
               'local_fname': fname5}
 supported_tags = {'': {'1min': basic_tag1,
                        '5min': basic_tag5}}
-print(supported_tags)
 download = functools.partial(cdw.download,
                              supported_tags,
                              fake_daily_files_from_monthly=True)

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -19,11 +19,11 @@ Files are stored by the first day of each month. When downloading use
 omni.download(start, stop, freq='MS') to only download days that could possibly
 have data.  'MS' gives a monthly start frequency.
 
-This material is based upon work supported by the 
-National Science Foundation under Grant Number 1259508. 
+This material is based upon work supported by the
+National Science Foundation under Grant Number 1259508.
 
-Any opinions, findings, and conclusions or recommendations expressed in this 
-material are those of the author(s) and do not necessarily reflect the views 
+Any opinions, findings, and conclusions or recommendations expressed in this
+material are those of the author(s) and do not necessarily reflect the views
 of the National Science Foundation.
 
 
@@ -108,11 +108,11 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
         raise ValueError (estr)
     else:
         return pysat.Files.from_os(data_path=data_path, format_str=format_str)
-            
+
 
 def load(fnames, tag=None, sat_id=None):
     import pysatCDF
-    
+
     if len(fnames) <= 0 :
         return pysat.DataFrame(None), None
     else:
@@ -123,7 +123,7 @@ def load(fnames, tag=None, sat_id=None):
             data, meta = cdf.to_pysat()
             # pick out data for date
             data = data.ix[date:date+pds.DateOffset(days=1) -
-                           pds.DateOffset(microseconds=1)] 
+                           pds.DateOffset(microseconds=1)]
             return data, meta
 
 def clean(omni):
@@ -133,7 +133,7 @@ def clean(omni):
             # get real name
             fill_attr = omni.meta.attr_case_name(fill_attr)
             for key in omni.data.columns:
-                if key != 'Epoch':    
+                if key != 'Epoch':
                     idx, = np.where(omni[key] == omni.meta[key, fill_attr])
                     omni[idx, key] = np.nan
     return
@@ -151,13 +151,13 @@ def time_shift_to_magnetic_poles(inst):
     ---------
     Time shift calculated using distance to bow shock nose (BSN)
     and velocity of solar wind along x-direction.
-    
+
     Warnings
     --------
     Use at own risk.
-    
+
     """
-    
+
     # need to fill in Vx to get an estimate of what is going on
     inst['Vx'] = inst['Vx'].interpolate('nearest')
     inst['Vx'] = inst['Vx'].fillna(method='backfill')
@@ -181,8 +181,8 @@ def time_shift_to_magnetic_poles(inst):
     for i, time in enumerate(time_x_offset):
         new_index.append(inst.data.index[i] + time)
     inst.data.index = new_index
-    inst.data = inst.data.sort_index()    
-    
+    inst.data = inst.data.sort_index()
+
     return
 
 def download(date_array, tag, sat_id='', data_path=None, user=None,
@@ -205,36 +205,39 @@ def download(date_array, tag, sat_id='', data_path=None, user=None,
         Not used, CDAWeb provides password (default=None)
     """
     import os
-    import ftplib
+    import requests
 
-    ftp = ftplib.FTP('cdaweb.gsfc.nasa.gov')   # connect to host, default port
-    ftp.login()               # user anonymous, passwd anonymous@
-    
+    remote_site = 'https://cdaweb.gsfc.nasa.gov'
+
     if (tag == '1min') | (tag == '5min'):
-        ftp.cwd('/pub/data/omni/omni_cdaweb/hro_'+tag)
-    
+        remote_url = remote_site + '/pub/data/omni/omni_cdaweb/hro_' + tag
+
         for date in date_array:
-            fname = '{year1:4d}/omni_hro_' + tag + \
-                    '_{year2:4d}{month:02d}{day:02d}_v01.cdf'
-            fname = fname.format(year1=date.year, year2=date.year,
-                                 month=date.month, day=date.day)
-            local_fname = ''.join(['omni_hro_', tag, \
-            '_{year:4d}{month:02d}{day:02d}_v01.cdf']).format(year=date.year, \
-                                                month=date.month, day=date.day)
-            saved_fname = os.path.join(data_path,local_fname) 
+            remote_fname = ''.join(('{year1:4d}/omni_hro_', tag,
+                                    '_{year2:4d}{month:02d}{day:02d}_v01.cdf'))
+            remote_fname = remote_fname.format(year1=date.year,
+                                               year2=date.year,
+                                               month=date.month,
+                                               day=date.day)
+            local_fname = ''.join(('omni_hro_', tag,
+                                   '_{year:4d}{month:02d}{day:02d}_v01.cdf'))
+            local_fname = local_fname.format(year=date.year,
+                                             month=date.month,
+                                             day=date.day)
+            saved_local_fname = os.path.join(data_path, local_fname)
             try:
                 print('Downloading file for '+date.strftime('%D'))
                 sys.stdout.flush()
-                ftp.retrbinary('RETR '+fname, open(saved_fname,'wb').write)
-            except ftplib.error_perm as exception:
-                # if exception[0][0:3] != '550':
-                if str(exception.args[0]).split(" ", 1)[0] != '550':
-                    raise
+                remote_path = '/'.join((remote_url, remote_fname))
+                r = requests.get(remote_path)
+                if r.status_code != 404:
+                    open(saved_local_fname, 'wb').write(r.content)
+                    print('Finished.')
                 else:
-                    os.remove(saved_fname)
-                    print('File not available for '+ date.strftime('%D'))
-    ftp.close()
-    # ftp.quit()
+                    print('File not available for ' + date.strftime('%x'))
+            except requests.exceptions.RequestException as exception:
+                print('File not available for ' + date.strftime('%x'))
+
     return
 
 def calculate_clock_angle(inst):
@@ -245,7 +248,7 @@ def calculate_clock_angle(inst):
     inst : pysat.Instrument
         Instrument with OMNI HRO data
     """
-    
+
     # Calculate clock angle in degrees
     clock_angle = np.degrees(np.arctan2(inst['BY_GSM'], inst['BZ_GSM']))
     clock_angle[clock_angle < 0.0] += 360.0
@@ -344,9 +347,8 @@ def calculate_dayside_reconnection(inst):
     sin_htheta = np.power(np.sin(np.radians(0.5 * inst['clock_angle'])), 4.5)
     byz = inst['BYZ_GSM'] * 1.0e-9
     vx = inst['flow_speed'] * 1000.0
-    
+
     recon_day = 3.8 * rearth * vx * byz * sin_htheta * np.power((vx / 4.0e5),
                                                                 1.0/3.0)
     inst['recon_day'] = pds.Series(recon_day, index=inst.data.index)
     return
-

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -67,7 +67,8 @@ test_dates = {'': {'1min': pysat.datetime(2009, 1, 1),
 # support list files routine
 # use the default CDAWeb method
 fname = 'omni_hro_{tag:4s}_{year:4d}{month:02d}{day:02d}_v01.cdf'
-supported_tags = {'': {'': fname}}
+supported_tags = {'': {'1min': fname,
+                       '5min': fname}}
 list_files = functools.partial(cdw.list_files,
                                supported_tags=supported_tags)
 
@@ -80,7 +81,8 @@ load = cdw.load
 basic_tag = {'dir': '/pub/data/omni/omni_cdaweb/hro_{tag:4s}',
              'remote_fname': '{year:4d}/' + fname,
              'local_fname': fname}
-supported_tags = {'': {'': basic_tag}}
+supported_tags = {'': {'1min': basic_tag,
+                       '5min': basic_tag}}
 download = functools.partial(cdw.download, supported_tags=supported_tags,
                              fake_daily_files_from_monthly=True)
 

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -60,17 +60,19 @@ platform = 'omni'
 name = 'hro'
 tags = {'1min': '1-minute time averaged data',
         '5min': '5-minute time averaged data'}
-sat_ids = {'': ['1min', '5min']}
+sat_ids = {'': ['5min']}
 test_dates = {'': {'1min': pysat.datetime(2009, 1, 1),
                    '5min': pysat.datetime(2009, 1, 1)}}
 
 # support list files routine
 # use the default CDAWeb method
-fname = 'omni_hro_{tag:4s}_{year:4d}{month:02d}{day:02d}_v01.cdf'
-supported_tags = {'': {'1min': fname,
-                       '5min': fname}}
+fname1 = 'omni_hro_1min_{year:4d}{month:02d}{day:02d}_v01.cdf'
+fname5 = 'omni_hro_5min_{year:4d}{month:02d}{day:02d}_v01.cdf'
+supported_tags = {'': {'1min': fname1,
+                       '5min': fname5}}
 list_files = functools.partial(cdw.list_files,
-                               supported_tags=supported_tags)
+                               supported_tags=supported_tags,
+                               fake_daily_files_from_monthly=True)
 
 # support load routine
 # use the default CDAWeb method
@@ -78,12 +80,17 @@ load = cdw.load
 
 # support download routine
 # use the default CDAWeb method
-basic_tag = {'dir': '/pub/data/omni/omni_cdaweb/hro_{tag:4s}',
-             'remote_fname': '{year:4d}/' + fname,
-             'local_fname': fname}
-supported_tags = {'': {'1min': basic_tag,
-                       '5min': basic_tag}}
-download = functools.partial(cdw.download, supported_tags=supported_tags,
+basic_tag1 = {'dir': '/pub/data/omni/omni_cdaweb/hro_1min',
+              'remote_fname': '{year:4d}/' + fname1,
+              'local_fname': fname1}
+basic_tag5 = {'dir': '/pub/data/omni/omni_cdaweb/hro_5min',
+              'remote_fname': '{year:4d}/' + fname5,
+              'local_fname': fname5}
+supported_tags = {'': {'1min': basic_tag1,
+                       '5min': basic_tag5}}
+print(supported_tags)
+download = functools.partial(cdw.download,
+                             supported_tags,
                              fake_daily_files_from_monthly=True)
 
 

--- a/pysat/instruments/supermag_magnetometer.py
+++ b/pysat/instruments/supermag_magnetometer.py
@@ -913,8 +913,7 @@ def append_ascii_data(file_strings, tag):
     idates = list() # Indices for the date lines
     date_list = list() # List of dates
     num_stations = list() # Number of stations for each date line
-    ind_num = 2 if tag in ['all', 'indices', ''] else 0
-    # ind_num = 2 if tag == '' else ind_num
+    ind_num = 2 if tag in ['all', 'indices'] else 0
 
     # Find the index information for the data
     for i,line in enumerate(out_lines):

--- a/pysat/instruments/supermag_magnetometer.py
+++ b/pysat/instruments/supermag_magnetometer.py
@@ -17,11 +17,11 @@ Note
 Files must be downloaded from the website, and is freely available after
 registration.
 
-This material is based upon work supported by the 
-National Science Foundation under Grant Number 1259508. 
+This material is based upon work supported by the
+National Science Foundation under Grant Number 1259508.
 
-Any opinions, findings, and conclusions or recommendations expressed in this 
-material are those of the author(s) and do not necessarily reflect the views 
+Any opinions, findings, and conclusions or recommendations expressed in this
+material are those of the author(s) and do not necessarily reflect the views
 of the National Science Foundation.
 
 
@@ -29,12 +29,12 @@ Warnings
 --------
 - Currently no cleaning routine, though the SuperMAG description indicates that
   these products are expected to be good.  More information about the processing
-  is available 
+  is available
 - Module not written by the SuperMAG team.
 
 Custom Functions
 -----------------
-                           
+
 """
 
 from __future__ import print_function, absolute_import
@@ -56,9 +56,9 @@ test_dates = {'':{kk:pysat.datetime(2009,1,1) for kk in tags.keys()}}
 
 def init(self):
     """Initializes the Instrument object with instrument specific values.
-    
+
     Runs once upon instantiation.
-    
+
     Parameters
     ----------
     self : pysat.Instrument
@@ -68,8 +68,8 @@ def init(self):
     --------
     Void : (NoneType)
         Object modified in place.
-    
-    
+
+
     """
 
     # if the tag is 'indices', update data_path to reflect this
@@ -80,23 +80,23 @@ def init(self):
 
     # reset the list_remote_files routine to include the data path
     # now conveniently included with instrument object
-    self._list_remote_rtn = functools.partial(list_remote_files, 
+    self._list_remote_rtn = functools.partial(list_remote_files,
                                                data_path=self.files.data_path,
                                                format_str=self.files.file_format)
-    return 
+    return
 
 
 def list_remote_files(tag, sat_id, data_path=None, format_str=None):
     """Lists remote files available for SuperMAG.
-    
+
     Note
     ----
-    Given the setup of the SuperMAG system, files aren't directly 
+    Given the setup of the SuperMAG system, files aren't directly
     available as the requested data is put into files as requested.
     To enable the functionality of keeping SuperMAG up to date, we
     fake the files here such that data from 1970 through the present
     is downloaded.
-    
+
     Parameters
     ----------
     tag : (string or NoneType)
@@ -111,7 +111,7 @@ def list_remote_files(tag, sat_id, data_path=None, format_str=None):
         Series indexed by date that stores the filename for each date.
 
     """
-    
+
     # given the function of SuperMAG, create a fake list of files
     # starting 01 Jan 1970, through today
     now = pysat.datetime.now()
@@ -126,14 +126,14 @@ def list_remote_files(tag, sat_id, data_path=None, format_str=None):
     index = pds.period_range(pysat.datetime(1970,1,1), now, freq=freq)
     # pre fill in blank strings
     remote_files = pds.Series(['']*len(index), index=index)
-    
+
     # pysat compares both dates and filenames when determining
     # which files it needs to download
     # so we need to ensure that filename for dates that overlap
     # are the same or data that is already present will be redownloaded
-    
+
     # need to get a list of the current files attached to
-    # the Instrument object. In this case, the object hasn't 
+    # the Instrument object. In this case, the object hasn't
     # been passed in.....
     #   that is ok, we can just call list_files right here
     #   except we don't have the data path
@@ -143,10 +143,10 @@ def list_remote_files(tag, sat_id, data_path=None, format_str=None):
     # iterating directly since pandas is complaining about periods
     # between different between indexes
     local_files = list_files(tag, sat_id, data_path, format_str)
-    for time, fname in local_files.iteritems():   
+    for time, fname in local_files.iteritems():
         remote_files.loc[time] = fname
     return remote_files
-    
+
 
 def list_files(tag='', sat_id=None, data_path=None, format_str=None):
     """Return a Pandas Series of every file for chosen SuperMAG data
@@ -170,7 +170,7 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
     --------
     pysat.Files.from_os : (pysat._files.Files)
         A pandas Series containing the verified available files
-        
+
     """
     if format_str is None and data_path is not None:
         file_base = 'supermag_magnetometer'
@@ -191,7 +191,7 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
         files = pysat.Files.from_os(data_path=data_path, format_str=min_fmt)
 
         # station files are once per year but we need to
-        # create the illusion there is a file per year        
+        # create the illusion there is a file per year
         if not files.empty:
             files = files.sort_index()
 
@@ -216,7 +216,7 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
         raise ValueError (estr)
     else:
         return pysat.Files.from_os(data_path=data_path, format_str=format_str)
- 
+
 
 def load(fnames, tag='', sat_id=None):
     """ Load the SuperMAG files
@@ -237,7 +237,7 @@ def load(fnames, tag='', sat_id=None):
         Object containing satellite data
     meta : (pysat.Meta)
         Object containing metadata such as column names and units
-        
+
     """
 
     # Ensure that there are files to load
@@ -299,7 +299,7 @@ def load_csv_data(fname, tag):
     --------
     data : (pandas.DataFrame)
         Pandas DataFrame
-        
+
     """
     import re
 
@@ -334,12 +334,12 @@ def load_csv_data(fname, tag):
                             ddict[dkeys[i]].append(ll)
                         else:
                             ddict[dkeys[-1]][-1] += " {:s}".format(ll)
-                            
+
         # Create a data frame for this file
         data = pds.DataFrame(ddict, index=date_list, columns=ddict.keys())
     else:
         # Define the date parser
-        def parse_smag_date(dd):                                               
+        def parse_smag_date(dd):
             return pysat.datetime.strptime(dd, "%Y-%m-%d %H:%M:%S")
 
         # Load the file into a data frame
@@ -347,7 +347,7 @@ def load_csv_data(fname, tag):
                             date_parser=parse_smag_date, index_col='datetime')
 
     return data
-            
+
 def load_ascii_data(fname, tag):
     """Load data from a self-documenting ASCII SuperMAG file
 
@@ -366,7 +366,7 @@ def load_ascii_data(fname, tag):
     baseline : (list)
         List of strings denoting the presence of a standard and file-specific
         baselines for each file.  None of not present or not applicable.
-        
+
     """
     import re
     ndata = {"indices":2, "":4, "all":4, "stations":8}
@@ -515,7 +515,7 @@ def update_smag_metadata(col_name):
     --------
     col_dict : (dict)
        Dictionary of strings detailing the units and long-form name of the data
-       
+
     """
 
     smag_units = {'IAGA':'none', 'N':'nT', 'E':'nT', 'Z':'nT', 'MLT':'hours',
@@ -542,7 +542,7 @@ def update_smag_metadata(col_name):
                  'STATION_NAME':'Long form station name',
                  'OPERATOR_NUM':'Number of station operators',
                  'OPERATORS':'Station operator name(s)',}
-    
+
     ackn = "When using this data please include the following reference:\n"
     ackn += "Gjerloev, J. W., The SuperMAG data processing technique, "
     ackn += "Geophys. Res., 117, A09213, doi:10.1029/2012JA017683, 2012\n\n"
@@ -566,7 +566,7 @@ def update_smag_metadata(col_name):
     ackn += "Vellante; BCMT, V. Lesur and A. Chambodut; Data obtained in "
     ackn += "cooperation with Geoscience Australia, PI Marina Costelloe; "
     ackn += "SuperMAG, PI Jesper W. Gjerloev."
-    
+
     col_dict = {'units':smag_units[col_name], 'long_name':smag_name[col_name],
                 'acknowledgements':ackn}
 
@@ -586,7 +586,7 @@ def format_baseline_list(baseline_list):
     ---------
     base_string : (str)
         Single string containing the relevent data
-        
+
     """
 
     uniq_base = dict()
@@ -673,11 +673,11 @@ def download(date_array, tag, sat_id='', data_path=None, user=None,
 
     Returns
     -------
-    
+
     """
     import sys
     import requests
-    
+
     global platform, name
 
     max_stations = 470
@@ -712,7 +712,7 @@ def download(date_array, tag, sat_id='', data_path=None, user=None,
     remoteaccess['filefmt'] = 'fmt={:s}'.format(file_fmt)
 
     # If indices are requested, add them now.
-    if not tag in [None, 'stations']:
+    if not tag in ['', 'stations']:
         remoteaccess['options'] += "+envelope"
 
     # Add other download options (for non-station files)
@@ -742,7 +742,7 @@ def download(date_array, tag, sat_id='', data_path=None, user=None,
         # Set the time information and format
         remoteaccess['interval'] = "interval=23:59"
         sfmt = "%Y-%m-%dT00:00:00.000"
-        tag_str = "_" if tag is None else "_all_" 
+        tag_str = "_" if tag is "" else "_all_"
         ffmt = "{:s}_{:s}{:s}%Y%m%d.{:s}".format(platform, name, tag_str,
                                                  "txt" if file_fmt == "ascii"
                                                  else file_fmt)
@@ -876,7 +876,7 @@ def append_data(file_strings, file_fmt, tag):
     -------
     out_string : string
         String with all data, ready for output to a file
-        
+
     """
     # Determine the right appending routine for the file type
     if file_fmt.lower() == "csv":
@@ -899,10 +899,10 @@ def append_ascii_data(file_strings, tag):
     -------
     out_string : string
         String with all data, ready for output to a file
-        
+
     """
     import re
-    
+
     # Start with data from the first list element
     out_lines = file_strings[0].split('\n')
     iparam = -1 # Index for the parameter line
@@ -935,7 +935,7 @@ def append_ascii_data(file_strings, tag):
 
     # Initialize a list of station names
     station_names = list()
-    
+
     # Cycle through each additional set of file strings
     for ff in range(len(file_strings)-1):
         file_lines = file_strings[ff+1].split('\n')
@@ -1006,7 +1006,7 @@ def append_csv_data(file_strings):
     -------
     out_string : string
         String with all data, ready for output to a file
-        
+
     """
     # Start with data from the first list element
     out_lines = list()

--- a/pysat/instruments/supermag_magnetometer.py
+++ b/pysat/instruments/supermag_magnetometer.py
@@ -190,7 +190,7 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
         else:
             min_fmt = '_'.join([file_base, '{year:4d}{month:02d}{day:02d}.???'])
             doff = pds.DateOffset(days=1)
-        print(min_fmt)
+
         files = pysat.Files.from_os(data_path=data_path, format_str=min_fmt)
 
         # station files are once per year but we need to

--- a/pysat/instruments/supermag_magnetometer.py
+++ b/pysat/instruments/supermag_magnetometer.py
@@ -86,7 +86,7 @@ def init(self):
     return
 
 
-def list_remote_files(tag='', sat_id=None, data_path=None, format_str=None):
+def list_remote_files(tag, sat_id, data_path=None, format_str=None):
     """Lists remote files available for SuperMAG.
 
     Note
@@ -190,6 +190,7 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
         else:
             min_fmt = '_'.join([file_base, '{year:4d}{month:02d}{day:02d}.???'])
             doff = pds.DateOffset(days=1)
+        print(min_fmt)
         files = pysat.Files.from_os(data_path=data_path, format_str=min_fmt)
 
         # station files are once per year but we need to

--- a/pysat/instruments/supermag_magnetometer.py
+++ b/pysat/instruments/supermag_magnetometer.py
@@ -72,6 +72,12 @@ def init(self):
     
     """
 
+    # if the tag is 'indices', update data_path to reflect this
+    # both 'indices' and 'all' are stored under 'all'
+    if self.tag == "indices":
+        psplit = path.split(self.files.data_path[:-1])
+        self.files.data_path = path.join(psplit[0], "all", "")
+
     # reset the list_remote_files routine to include the data path
     # now conveniently included with instrument object
     self._list_remote_rtn = functools.partial(list_remote_files, 
@@ -687,6 +693,9 @@ def download(date_array, tag, sat_id='', data_path=None, user=None,
     # Set the tag information
     if tag == "indices":
         tag = "all"
+        # modify path as 'indices' is stored under 'all'
+        psplit = path.split(data_path[:-1])
+        data_path = path.join(psplit[0], "all", "")
 
     if tag != "stations":
         remotefmt += "&{interval}&{stations}&{delta}&{baseline}&{options}"

--- a/pysat/instruments/supermag_magnetometer.py
+++ b/pysat/instruments/supermag_magnetometer.py
@@ -86,7 +86,7 @@ def init(self):
     return
 
 
-def list_remote_files(tag, sat_id, data_path=None, format_str=None):
+def list_remote_files(tag='', sat_id=None, data_path=None, format_str=None):
     """Lists remote files available for SuperMAG.
 
     Note
@@ -99,8 +99,10 @@ def list_remote_files(tag, sat_id, data_path=None, format_str=None):
 
     Parameters
     ----------
-    tag : (string or NoneType)
-        Denotes type of file to load.  Accepted types are <tag strings>. (default=None)
+    tag : (string)
+        Denotes type of file to load.  Accepted types are 'indices', 'all',
+        'stations', and '' (for just magnetometer measurements).
+        (default='')
     sat_id : (string or NoneType)
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
@@ -153,7 +155,7 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
 
     Parameters
     -----------
-    tag : (string or NoneType)
+    tag : (string)
         Denotes type of file to load.  Accepted types are 'indices', 'all',
         'stations', and '' (for just magnetometer measurements). (default='')
     sat_id : (string or NoneType)
@@ -225,7 +227,7 @@ def load(fnames, tag='', sat_id=None):
     -----------
     fnames : (list)
         List of filenames
-    tag : (str or NoneType)
+    tag : (str)
         Denotes type of file to load.  Accepted types are 'indices', 'all',
         'stations', and '' (for just magnetometer measurements). (default='')
     sat_id : (str or NoneType)
@@ -893,7 +895,7 @@ def append_ascii_data(file_strings, tag):
         Lists or arrays of strings, where each string contains one file of data
     tag : string
         String denoting the type of file to load, accepted values are 'indices',
-        'all', 'stations', and None (for only magnetometer data)
+        'all', 'stations', and '' (for only magnetometer data)
 
     Returns
     -------

--- a/pysat/instruments/supermag_magnetometer.py
+++ b/pysat/instruments/supermag_magnetometer.py
@@ -216,7 +216,7 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
         return files
     elif format_str is None:
         estr = 'A directory must be passed to the loading routine for SuperMAG'
-        raise ValueError (estr)
+        raise ValueError(estr)
     else:
         return pysat.Files.from_os(data_path=data_path, format_str=format_str)
 

--- a/pysat/instruments/sw_dst.py
+++ b/pysat/instruments/sw_dst.py
@@ -152,10 +152,9 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
             # each day of the month. The load routine will load a month of
             # data and use the appended date to select out appropriate data.
             if format_str is None:
-                format_str = 'dst{year:2d}.txt'
+                format_str = 'dst{year:4d}.txt'
             out = pysat.Files.from_os(data_path=data_path, 
-                format_str=format_str,
-                two_digit_year_break=94)
+                                      format_str=format_str)
             if not out.empty:
                 out.ix[out.index[-1]+pds.DateOffset(years=1)-
                          pds.DateOffset(days=1)] = out.iloc[-1]  

--- a/pysat/tests/test_ftp_instruments.py
+++ b/pysat/tests/test_ftp_instruments.py
@@ -82,7 +82,7 @@ init_names = None
 print ("FTP Download check environment variable output ", os.environ.get('Travis'),
        os.environ.get('TRAVIS'), os.environ.get('CI'))
 
-if not os.environ.get('Travis') == 'True':
+if not (os.environ.get('TRAVIS') == 'true'):
     class TestFTPInstrumentQualifier(pysat.tests.test_instruments.TestInstrumentQualifier):
     
         def __init__(self):

--- a/pysat/tests/test_ftp_instruments.py
+++ b/pysat/tests/test_ftp_instruments.py
@@ -1,16 +1,13 @@
 """
 tests the pysat meta object and code
 """
-import pysat
+import importlib
+import os
 import tempfile
 
-
+import pysat
 import pysat.instruments.pysat_testing
 import pysat.tests.test_instruments
-# import pysat.instruments as instruments
-import os
-
-import importlib
 
 include_list = ['sw_dst', 'sw_kp']
 # dict, keyed by pysat instrument, with a list of usernames and passwords

--- a/pysat/tests/test_ftp_instruments.py
+++ b/pysat/tests/test_ftp_instruments.py
@@ -1,0 +1,109 @@
+"""
+tests the pysat meta object and code
+"""
+import pysat
+import tempfile
+
+
+import pysat.instruments.pysat_testing
+import pysat.tests.test_instruments
+# import pysat.instruments as instruments
+import os
+
+import importlib
+
+include_list = ['sw_dst', 'sw_kp']
+# dict, keyed by pysat instrument, with a list of usernames and passwords
+user_download_dict = {}
+
+def safe_data_dir():
+    saved_path = pysat.data_dir
+    if saved_path is '':
+        saved_path = '.'
+    return saved_path
+
+def init_func_external(self):
+    """Iterate through and create all of the test Instruments needed.
+       Only want to do this once.
+
+    """
+
+    # names of all the instrument modules
+    instrument_names = pysat.instruments.__all__
+    temp = []
+    for name in instrument_names:
+        if name in include_list:
+            temp.append(name)
+    instrument_names = temp
+    self.instrument_names = temp
+    self.instruments = []
+    self.instrument_modules = []
+
+    # create temporary directory
+    dir_name = tempfile.mkdtemp()
+    saved_path = safe_data_dir()
+    pysat.utils.set_data_dir(dir_name, store=False)
+
+    for name in instrument_names:
+        try:
+            print(' '.join(('FTP', name)))
+            module = importlib.import_module(''.join(('.', name)), package='pysat.instruments')
+        except ImportError:
+            print ("Couldn't import instrument module")
+            pass
+        else:
+            # try and grab basic information about the module so we
+            # can iterate over all of the options
+            try:
+                info = module.test_dates
+            except AttributeError:
+                info = {}
+                info[''] = {'':pysat.datetime(2009,1,1)}
+                module.test_dates = info
+            for sat_id in info.keys() :
+                for tag in info[sat_id].keys():
+                    try:
+                        inst = pysat.Instrument(inst_module=module,
+                                                tag=tag,
+                                                sat_id=sat_id,
+                                                temporary_file_list=True)
+                        inst.test_dates = module.test_dates
+                        self.instruments.append(inst)
+                        self.instrument_modules.append(module)
+                    except:
+                        pass
+    pysat.utils.set_data_dir(saved_path, store=False)
+
+init_inst = None
+init_mod = None
+init_names = None
+
+# this environment variable is set by the TRAVIS CI folks
+if not os.environ.get('Travis') == 'True':
+    class TestFTPInstrumentQualifier(pysat.tests.test_instruments.TestInstrumentQualifier):
+    
+        def __init__(self):
+            """Iterate through and create all of the test Instruments needed"""
+            global init_inst
+            global init_mod
+            global init_names
+            
+            if init_inst is None:
+                init_func_external(self)
+                init_inst = self.instruments
+                init_mod = self.instrument_modules
+                init_names = self.instrument_names
+    
+            else:
+                self.instruments = init_inst
+                self.instrument_modules = init_mod
+                self.instrument_names = init_names
+    
+        def setup(self):
+            """Runs before every method to create a clean testing setup."""
+            pass
+    
+        def teardown(self):
+            """Runs after every method to clean up previous testing."""
+            pass
+

--- a/pysat/tests/test_ftp_instruments.py
+++ b/pysat/tests/test_ftp_instruments.py
@@ -1,5 +1,7 @@
 """
-tests the pysat meta object and code
+tests the pysat meta object and code for instruments with ftp downloads.
+
+Intended to be run locally, excluded from Travis CI
 """
 import importlib
 import os
@@ -9,15 +11,19 @@ import pysat
 import pysat.instruments.pysat_testing
 import pysat.tests.test_instruments
 
-include_list = ['sw_dst', 'sw_kp']
+include_list = ['sw_dst']
+include_tags = {'sw_f107': {'tag': ['prelim'], 'sat_id': ['']},
+                'sw_kp': {'tag': [''], 'sat_id': ['']}}
 # dict, keyed by pysat instrument, with a list of usernames and passwords
 user_download_dict = {}
+
 
 def safe_data_dir():
     saved_path = pysat.data_dir
     if saved_path is '':
         saved_path = '.'
     return saved_path
+
 
 def init_func_external(self):
     """Iterate through and create all of the test Instruments needed.
@@ -44,9 +50,10 @@ def init_func_external(self):
     for name in instrument_names:
         try:
             print(' '.join(('FTP', name)))
-            module = importlib.import_module(''.join(('.', name)), package='pysat.instruments')
+            module = importlib.import_module(''.join(('.', name)),
+                                             package='pysat.instruments')
         except ImportError:
-            print ("Couldn't import instrument module")
+            print("Couldn't import instrument module")
             pass
         else:
             # try and grab basic information about the module so we
@@ -55,9 +62,9 @@ def init_func_external(self):
                 info = module.test_dates
             except AttributeError:
                 info = {}
-                info[''] = {'':pysat.datetime(2009,1,1)}
+                info[''] = {'': pysat.datetime(2009, 1, 1)}
                 module.test_dates = info
-            for sat_id in info.keys() :
+            for sat_id in info.keys():
                 for tag in info[sat_id].keys():
                     try:
                         inst = pysat.Instrument(inst_module=module,
@@ -71,38 +78,39 @@ def init_func_external(self):
                         pass
     pysat.utils.set_data_dir(saved_path, store=False)
 
+
 init_inst = None
 init_mod = None
 init_names = None
 
 # this environment variable is set by the TRAVIS CI folks
-# print ("FTP Download check environment variable output ", os.environ.get('Travis'),
+# print ("FTP Download check environment variable output ",
+#        os.environ.get('Travis'),
 #        os.environ.get('TRAVIS'), os.environ.get('CI'))
 if not (os.environ.get('TRAVIS') == 'true'):
     class TestFTPInstrumentQualifier(pysat.tests.test_instruments.TestInstrumentQualifier):
-    
+
         def __init__(self):
             """Iterate through and create all of the test Instruments needed"""
             global init_inst
             global init_mod
             global init_names
-            
+
             if init_inst is None:
                 init_func_external(self)
                 init_inst = self.instruments
                 init_mod = self.instrument_modules
                 init_names = self.instrument_names
-    
+
             else:
                 self.instruments = init_inst
                 self.instrument_modules = init_mod
                 self.instrument_names = init_names
-    
+
         def setup(self):
             """Runs before every method to create a clean testing setup."""
             pass
-    
+
         def teardown(self):
             """Runs after every method to clean up previous testing."""
             pass
-

--- a/pysat/tests/test_ftp_instruments.py
+++ b/pysat/tests/test_ftp_instruments.py
@@ -79,6 +79,9 @@ init_mod = None
 init_names = None
 
 # this environment variable is set by the TRAVIS CI folks
+print ("FTP Download check environment variable output ", os.environ.get('Travis'),
+       os.environ.get('TRAVIS'), os.environ.get('CI'))
+
 if not os.environ.get('Travis') == 'True':
     class TestFTPInstrumentQualifier(pysat.tests.test_instruments.TestInstrumentQualifier):
     

--- a/pysat/tests/test_ftp_instruments.py
+++ b/pysat/tests/test_ftp_instruments.py
@@ -12,8 +12,6 @@ import pysat.instruments.pysat_testing
 import pysat.tests.test_instruments
 
 include_list = ['sw_dst']
-include_tags = {'sw_f107': {'tag': ['prelim'], 'sat_id': ['']},
-                'sw_kp': {'tag': [''], 'sat_id': ['']}}
 # dict, keyed by pysat instrument, with a list of usernames and passwords
 user_download_dict = {}
 

--- a/pysat/tests/test_ftp_instruments.py
+++ b/pysat/tests/test_ftp_instruments.py
@@ -79,9 +79,8 @@ init_mod = None
 init_names = None
 
 # this environment variable is set by the TRAVIS CI folks
-print ("FTP Download check environment variable output ", os.environ.get('Travis'),
-       os.environ.get('TRAVIS'), os.environ.get('CI'))
-
+# print ("FTP Download check environment variable output ", os.environ.get('Travis'),
+#        os.environ.get('TRAVIS'), os.environ.get('CI'))
 if not (os.environ.get('TRAVIS') == 'true'):
     class TestFTPInstrumentQualifier(pysat.tests.test_instruments.TestInstrumentQualifier):
     

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -1,31 +1,25 @@
 """
 tests the pysat meta object and code
 """
-import pysat
-import pandas as pds
-from nose.tools import assert_raises, raises
-import nose.tools
+import importlib
 from functools import partial
+import numpy as np
+import sys
+
+import nose.tools
+import pandas as pds
 import tempfile
 
-
+import pysat
 import pysat.instruments.pysat_testing
-# import pysat.instruments as instruments
-import numpy as np
-# import os
-
-
-import sys
-import importlib
 
 # module in list below are excluded from download checks
 exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps',
                 'icon_euv', 'icon_ivm', 'icon_mighti', 'icon_fuv', 'sw_dst', 
-                'sw_kp', 'demeter_iap', 'sport_ivm']
-                
+                'sw_kp', 'demeter_iap', 'sport_ivm']                
 
 # exclude testing download functionality for specific module name, tag, sat_id 
-exclude_tags = {'': {'tag': [''], 'sat_id': ['']}}
+exclude_tags = {'sw_f107': {'tag': ['prelim'], 'sat_id': ['']}}
 
 # dict, keyed by pysat instrument, with a list of usernames and passwords
 user_download_dict = {'supermag_magnetometer':['rstoneback', None]}

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -17,7 +17,7 @@ import pysat.instruments.pysat_testing
 exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps',
                 'cosmic2013_gps', 'demeter_iap', 'sport_ivm',
                 'icon_euv', 'icon_ivm', 'icon_mighti', 'icon_fuv',
-                'sw_dst']
+                'sw_dst', 'ucar_tiegcm']
 
 # exclude testing download functionality for specific module name, tag, sat_id
 exclude_tags = {'sw_f107': {'tag': ['prelim'], 'sat_id': ['']},

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -20,14 +20,10 @@ import importlib
 
 # module in list below are excluded from download checks
 exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps',
-<<<<<<< HEAD
                 'icon_euv', 'icon_ivm', 'icon_mighti', 'icon_fuv', 'sw_dst', 
                 'sw_kp', 'demeter_iap', 'sport_ivm']
                 
-=======
-                'icon_euv', 'icon_ivm', 'sw_dst', 'sw_kp']
 
->>>>>>> aebd70b14ae6b17c72187cf9a32e074ca2ba43ae
 # exclude testing download functionality for specific module name, tag, sat_id 
 exclude_tags = {'': {'tag': [''], 'sat_id': ['']}}
 
@@ -57,13 +53,11 @@ def init_func_external(self):
         if name not in exclude_list:
             temp.append(name)
     instrument_names = temp
-<<<<<<< HEAD
+    
     print ('The following instrument modules will be tested : ', 
            instrument_names)
     
-=======
 
->>>>>>> aebd70b14ae6b17c72187cf9a32e074ca2ba43ae
     self.instrument_names = temp
     self.instruments = []
     self.instrument_modules = []
@@ -164,12 +158,8 @@ class TestInstrumentQualifier():
 
     def test_modules_loadable(self):
 
-<<<<<<< HEAD
         # ensure that all modules are at minimum importable
         for name in pysat.instruments.__all__: 
-=======
-        for name in self.instrument_names:
->>>>>>> aebd70b14ae6b17c72187cf9a32e074ca2ba43ae
             f = partial(self.check_module_importable, name)
             f.description = ' '.join(('Checking importability for module:', name))
             yield (f,)

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -80,7 +80,7 @@ def init_func_external(self):
                 for tag in info[sat_id].keys():
                     if name in exclude_tags:
                         if tag in exclude_tags[name]['tag'] and \
-                                 sat_id in exclude_tags[name]['sat_id']:
+                                  sat_id in exclude_tags[name]['sat_id']:
                             # drop out of for loop
                             # we don't want to test download for this combo
                             break

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -21,13 +21,13 @@ import importlib
 # module in list below are completely excluded
 exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps',
                 'icon_euv', 'icon_ivm', 'sw_dst', 'sw_kp']
-# exclude specific tag, sat_id combinations for specific modules
-# when testing download functionality
-# keyed by module name
+                
+# exclude testing download functionality for specific module name, tag, sat_id 
 exclude_tags = {'': {'tag': [''], 'sat_id': ['']}}
 
 # dict, keyed by pysat instrument, with a list of usernames and passwords
 user_download_dict = {'supermag_magnetometer':['rstoneback', None]}
+
 
 if sys.version_info[0] >= 3:
     # TODO Remove when pyglow works in python 3

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -18,9 +18,10 @@ import numpy as np
 import sys
 import importlib
 
-# module in list below are completely excluded
+# module in list below are excluded from download checks
 exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps',
-                'icon_euv', 'icon_ivm', 'sw_dst', 'sw_kp']
+                'icon_euv', 'icon_ivm', 'icon_mighti', 'icon_fuv', 'sw_dst', 
+                'sw_kp', 'demeter_iap', 'sport_ivm']
                 
 # exclude testing download functionality for specific module name, tag, sat_id 
 exclude_tags = {'': {'tag': [''], 'sat_id': ['']}}
@@ -51,6 +52,8 @@ def init_func_external(self):
         if name not in exclude_list:
             temp.append(name)
     instrument_names = temp
+    print ('The following instrument modules will be tested : ', 
+           instrument_names)
     
     self.instrument_names = temp
     self.instruments = []
@@ -83,6 +86,7 @@ def init_func_external(self):
                                   sat_id in exclude_tags[name]['sat_id']:
                             # drop out of for loop
                             # we don't want to test download for this combo
+                            print (' '.join('Excluding', name, tag, sat_id))
                             break
                     try:
                         inst = pysat.Instrument(inst_module=module,
@@ -107,6 +111,7 @@ class TestInstrumentQualifier():
         global init_inst
         global init_mod
         global init_names
+        
         if init_inst is None:
             init_func_external(self)
             init_inst = self.instruments
@@ -149,10 +154,9 @@ class TestInstrumentQualifier():
         assert np.all(check)
 
     def test_modules_loadable(self):
-        #instrument_names = pysat.instruments.__all__
-        #self.instruments = []
 
-        for name in self.instrument_names: 
+        # ensure that all modules are at minimum importable
+        for name in pysat.instruments.__all__: 
             f = partial(self.check_module_importable, name)
             f.description = ' '.join(('Checking importability for module:', name))
             yield (f,)

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -28,7 +28,6 @@ exclude_tags = {'': {'tag': [''], 'sat_id': ['']}}
 # dict, keyed by pysat instrument, with a list of usernames and passwords
 user_download_dict = {'supermag_magnetometer':['rstoneback', None]}
 
-
 if sys.version_info[0] >= 3:
     # TODO Remove when pyglow works in python 3
     exclude_list.append('pysat_sgp4')
@@ -307,11 +306,7 @@ class TestInstrumentQualifier():
                 f.description = ' '.join(('Checking load routine functionality for module with clean level "clean": ', inst.platform, inst.name, inst.tag, inst.sat_id))
                 yield (f,)
             else:
-                print ('Unable to actually download a file.')
-                # raise RuntimeWarning(' '.join(('Download for', inst.platform, inst.name, inst.tag, inst.sat_id, 'was not successful.')))
-                import warnings
-                warnings.warn(' '.join(('Download for', inst.platform, inst.name, inst.tag, inst.sat_id, 'was not successful.')))
-                #TODO need a warning!
+                raise RuntimeWarning(' '.join(('Download for', inst.platform, inst.name, inst.tag, inst.sat_id, 'was not successful.')))
 
 
     # Optional support

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -46,6 +46,8 @@ def init_func_external(self):
         if name not in exclude_list:
             temp.append(name)
     instrument_names = temp
+    
+    self.instrument_names = temp
     self.instruments = []
     self.instrument_modules = []
 
@@ -85,6 +87,7 @@ def init_func_external(self):
 
 init_inst = None
 init_mod = None
+init_names = None
 
 class TestInstrumentQualifier():
 
@@ -92,14 +95,17 @@ class TestInstrumentQualifier():
         """Iterate through and create all of the test Instruments needed"""
         global init_inst
         global init_mod
+        global init_names
         if init_inst is None:
             init_func_external(self)
             init_inst = self.instruments
             init_mod = self.instrument_modules
+            init_names = self.instrument_names
 
         else:
             self.instruments = init_inst
             self.instrument_modules = init_mod
+            self.instrument_names = init_names
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""
@@ -132,10 +138,10 @@ class TestInstrumentQualifier():
         assert np.all(check)
 
     def test_modules_loadable(self):
-        instrument_names = pysat.instruments.__all__
-        self.instruments = []
+        #instrument_names = pysat.instruments.__all__
+        #self.instruments = []
 
-        for name in instrument_names:
+        for name in self.instrument_names: 
             f = partial(self.check_module_importable, name)
             f.description = ' '.join(('Checking importability for module:', name))
             yield (f,)

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -14,15 +14,17 @@ import pysat
 import pysat.instruments.pysat_testing
 
 # module in list below are excluded from download checks
-exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps',
-                'icon_euv', 'icon_ivm', 'icon_mighti', 'icon_fuv', 'sw_dst', 
-                'sw_kp', 'demeter_iap', 'sport_ivm']                
+exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps',
+                'cosmic2013_gps', 'demeter_iap', 'sport_ivm',
+                'icon_euv', 'icon_ivm', 'icon_mighti', 'icon_fuv',
+                'sw_dst']
 
-# exclude testing download functionality for specific module name, tag, sat_id 
-exclude_tags = {'sw_f107': {'tag': ['prelim'], 'sat_id': ['']}}
+# exclude testing download functionality for specific module name, tag, sat_id
+exclude_tags = {'sw_f107': {'tag': ['prelim'], 'sat_id': ['']},
+                'sw_kp': {'tag': [''], 'sat_id': ['']}}
 
 # dict, keyed by pysat instrument, with a list of usernames and passwords
-user_download_dict = {'supermag_magnetometer':['rstoneback', None]}
+user_download_dict = {'supermag_magnetometer': ['rstoneback', None]}
 
 if sys.version_info[0] >= 3:
     # TODO Remove when pyglow works in python 3
@@ -47,10 +49,9 @@ def init_func_external(self):
         if name not in exclude_list:
             temp.append(name)
     instrument_names = temp
-    
-    print ('The following instrument modules will be tested : ', 
-           instrument_names)
-    
+
+    print('The following instrument modules will be tested : ',
+          instrument_names)
 
     self.instrument_names = temp
     self.instruments = []
@@ -66,7 +67,7 @@ def init_func_external(self):
             module = importlib.import_module(''.join(('.', name)),
                                              package='pysat.instruments')
         except ImportError:
-            print ("Couldn't import instrument module")
+            print("Couldn't import instrument module")
             pass
         else:
             # try and grab basic information about the module so we
@@ -75,16 +76,16 @@ def init_func_external(self):
                 info = module.test_dates
             except AttributeError:
                 info = {}
-                info[''] = {'':pysat.datetime(2009,1,1)}
+                info[''] = {'': pysat.datetime(2009, 1, 1)}
                 module.test_dates = info
-            for sat_id in info.keys() :
+            for sat_id in info.keys():
                 for tag in info[sat_id].keys():
                     if name in exclude_tags:
                         if tag in exclude_tags[name]['tag'] and \
                                   sat_id in exclude_tags[name]['sat_id']:
                             # drop out of for loop
                             # we don't want to test download for this combo
-                            print (' '.join(['Excluding', name, tag, sat_id]))
+                            print(' '.join(['Excluding', name, tag, sat_id]))
                             break
                     try:
                         inst = pysat.Instrument(inst_module=module,
@@ -98,9 +99,11 @@ def init_func_external(self):
                         pass
     pysat.utils.set_data_dir(saved_path, store=False)
 
+
 init_inst = None
 init_mod = None
 init_names = None
+
 
 class TestInstrumentQualifier():
 
@@ -109,7 +112,7 @@ class TestInstrumentQualifier():
         global init_inst
         global init_mod
         global init_names
-        
+
         if init_inst is None:
             init_func_external(self)
             init_inst = self.instruments
@@ -155,7 +158,7 @@ class TestInstrumentQualifier():
     def test_modules_loadable(self):
 
         # ensure that all modules are at minimum importable
-        for name in pysat.instruments.__all__: 
+        for name in pysat.instruments.__all__:
             f = partial(self.check_module_importable, name)
             f.description = ' '.join(('Checking importability for module:',
                                       name))
@@ -170,8 +173,8 @@ class TestInstrumentQualifier():
                 # try and grab basic information about the module so we
                 # can iterate over all of the options
                 f = partial(self.check_module_info, module)
-                f.description = ' '.join(('Checking module has platform, name, '
-                                          + 'tags, sat_ids. Testing module:',
+                f.description = ' '.join(('Checking module has platform, name,'
+                                          + ' tags, sat_ids. Testing module:',
                                           name))
                 yield (f,)
 
@@ -179,8 +182,8 @@ class TestInstrumentQualifier():
                     info = module.test_dates
                 except AttributeError:
                     info = {}
-                    info[''] = {'':'failsafe'}
-                for sat_id in info.keys() :
+                    info[''] = {'': 'failsafe'}
+                for sat_id in info.keys():
                     for tag in info[sat_id].keys():
                         f = partial(self.check_module_loadable, module, tag,
                                     sat_id)
@@ -189,7 +192,6 @@ class TestInstrumentQualifier():
                                                   name, 'tag:', tag, 'sat id:',
                                                   sat_id))
                         yield (f, )
-
 
     def check_load_presence(self, inst):
         _ = inst.load
@@ -340,9 +342,9 @@ class TestInstrumentQualifier():
                 yield (f,)
             else:
                 raise RuntimeWarning(' '.join(('Download for', inst.platform,
-                                               inst.name, inst.tag, inst.sat_id,
+                                               inst.name, inst.tag,
+                                               inst.sat_id,
                                                'was not successful.')))
-
 
     # Optional support
 

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -17,7 +17,7 @@ import pysat.instruments.pysat_testing
 exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps',
                 'cosmic2013_gps', 'demeter_iap', 'sport_ivm',
                 'icon_euv', 'icon_ivm', 'icon_mighti', 'icon_fuv',
-                'sw_dst', 'ucar_tiegcm']
+                'sw_dst']
 
 # exclude testing download functionality for specific module name, tag, sat_id
 exclude_tags = {'sw_f107': {'tag': ['prelim'], 'sat_id': ['']},

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -84,7 +84,7 @@ def init_func_external(self):
                                   sat_id in exclude_tags[name]['sat_id']:
                             # drop out of for loop
                             # we don't want to test download for this combo
-                            print (' '.join('Excluding', name, tag, sat_id))
+                            print (' '.join(['Excluding', name, tag, sat_id]))
                             break
                     try:
                         inst = pysat.Instrument(inst_module=module,
@@ -250,7 +250,7 @@ class TestInstrumentQualifier():
             print("Couldn't download data, trying to find test data.")
             saved_path = safe_data_dir()
 
-            new_path = os.path.join(pysat.__path__[0],'tests', 'test_data')
+            new_path = os.path.join(pysat.__path__[0], 'tests', 'test_data')
             pysat.utils.set_data_dir(new_path, store=False)
             test_dates = inst.test_dates
             inst = pysat.Instrument(platform=inst.platform,
@@ -339,7 +339,9 @@ class TestInstrumentQualifier():
                                           inst.name, inst.tag, inst.sat_id))
                 yield (f,)
             else:
-                raise RuntimeWarning(' '.join(('Download for', inst.platform, inst.name, inst.tag, inst.sat_id, 'was not successful.')))
+                raise RuntimeWarning(' '.join(('Download for', inst.platform,
+                                               inst.name, inst.tag, inst.sat_id,
+                                               'was not successful.')))
 
 
     # Optional support

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -18,8 +18,14 @@ import numpy as np
 import sys
 import importlib
 
+# module in list below are completely excluded
 exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps',
                 'icon_euv', 'icon_ivm', 'sw_dst', 'sw_kp']
+# exclude specific tag, sat_id combinations for specific modules
+# when testing download functionality
+# keyed by module name
+exclude_tags = {'': {'tag': [''], 'sat_id': ['']}}
+
 # dict, keyed by pysat instrument, with a list of usernames and passwords
 user_download_dict = {'supermag_magnetometer':['rstoneback', None]}
 
@@ -73,6 +79,12 @@ def init_func_external(self):
                 module.test_dates = info
             for sat_id in info.keys() :
                 for tag in info[sat_id].keys():
+                    if name in exclude_tags:
+                        if tag in exclude_tags[name]['tag'] and \
+                                 sat_id in exclude_tags[name]['sat_id']:
+                            # drop out of for loop
+                            # we don't want to test download for this combo
+                            break
                     try:
                         inst = pysat.Instrument(inst_module=module,
                                                 tag=tag,

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -18,15 +18,15 @@ import numpy as np
 import sys
 import importlib
 
-exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps', 
-                'icon_euv', 'icon_ivm']
+exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps',
+                'icon_euv', 'icon_ivm', 'sw_dst', 'sw_kp']
 # dict, keyed by pysat instrument, with a list of usernames and passwords
 user_download_dict = {'supermag_magnetometer':['rstoneback', None]}
 
 if sys.version_info[0] >= 3:
     # TODO Remove when pyglow works in python 3
     exclude_list.append('pysat_sgp4')
-    
+
 def safe_data_dir():
     saved_path = pysat.data_dir
     if saved_path is '':
@@ -36,8 +36,8 @@ def safe_data_dir():
 def init_func_external(self):
     """Iterate through and create all of the test Instruments needed.
        Only want to do this once.
-       
-    """    
+
+    """
 
     # names of all the instrument modules
     instrument_names = pysat.instruments.__all__
@@ -49,11 +49,11 @@ def init_func_external(self):
     self.instruments = []
     self.instrument_modules = []
 
-    # create temporary directory  
+    # create temporary directory
     dir_name = tempfile.mkdtemp()
     saved_path = safe_data_dir()
-    pysat.utils.set_data_dir(dir_name, store=False)    
-        
+    pysat.utils.set_data_dir(dir_name, store=False)
+
     for name in instrument_names:
         try:
             module = importlib.import_module(''.join(('.', name)), package='pysat.instruments')
@@ -68,26 +68,26 @@ def init_func_external(self):
             except AttributeError:
                 info = {}
                 info[''] = {'':pysat.datetime(2009,1,1)}
-                module.test_dates = info            
-            for sat_id in info.keys() :  
+                module.test_dates = info
+            for sat_id in info.keys() :
                 for tag in info[sat_id].keys():
                     try:
-                        inst = pysat.Instrument(inst_module=module, 
-                                                tag=tag, 
+                        inst = pysat.Instrument(inst_module=module,
+                                                tag=tag,
                                                 sat_id=sat_id,
-                                                temporary_file_list=True) 
+                                                temporary_file_list=True)
                         inst.test_dates = module.test_dates
                         self.instruments.append(inst)
                         self.instrument_modules.append(module)
                     except:
                         pass
     pysat.utils.set_data_dir(saved_path, store=False)
-            
+
 init_inst = None
 init_mod = None
-        
+
 class TestInstrumentQualifier():
-    
+
     def __init__(self):
         """Iterate through and create all of the test Instruments needed"""
         global init_inst
@@ -100,7 +100,7 @@ class TestInstrumentQualifier():
         else:
             self.instruments = init_inst
             self.instrument_modules = init_mod
-        
+
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         pass
@@ -112,11 +112,11 @@ class TestInstrumentQualifier():
     def check_module_loadable(self, module, tag, sat_id):
         a = pysat.Instrument(inst_module=module, tag=tag, sat_id=sat_id)
         assert True
-        
+
     def check_module_importable(self, name):
         module = importlib.import_module(''.join(('.', name)), package='pysat.instruments')
         assert True
-        
+
     def check_module_info(self, module):
         platform = module.platform
         name = module.name
@@ -130,16 +130,16 @@ class TestInstrumentQualifier():
         check.append(isinstance(sat_ids, dict))
         # that contains lists
         assert np.all(check)
-    
+
     def test_modules_loadable(self):
         instrument_names = pysat.instruments.__all__
         self.instruments = []
-    
+
         for name in instrument_names:
             f = partial(self.check_module_importable, name)
             f.description = ' '.join(('Checking importability for module:', name))
             yield (f,)
-            
+
             try:
                 module = importlib.import_module(''.join(('.', name)), package='pysat.instruments')
             except ImportError:
@@ -155,8 +155,8 @@ class TestInstrumentQualifier():
                     info = module.test_dates
                 except AttributeError:
                     info = {}
-                    info[''] = {'':'failsafe'}            
-                for sat_id in info.keys() :  
+                    info[''] = {'':'failsafe'}
+                for sat_id in info.keys() :
                     for tag in info[sat_id].keys():
                         f = partial(self.check_module_loadable, module, tag, sat_id)
                         f.description = ' '.join(('Checking pysat.Instrument instantiation for module:', name, 'tag:', tag, 'sat id:', sat_id))
@@ -166,43 +166,43 @@ class TestInstrumentQualifier():
     def check_load_presence(self, inst):
         _ = inst.load
         assert True
-                
+
     def test_load_presence(self):
         for module in self.instrument_modules:
             f = partial(self.check_load_presence, module)
             f.description = ' '.join(('Checking for load routine for module: ', module.platform, module.name))
             yield (f,)
-            
+
     def check_list_files_presence(self, module):
         _ = module.list_files
         assert True
-                
+
     def test_list_files_presence(self):
         for module in self.instrument_modules:
             f = partial(self.check_list_files_presence, module)
             f.description = ' '.join(('Checking for list_files routine for module: ', module.platform, module.name))
             yield (f,)
-            
+
     def check_download_presence(self, inst):
         _ = inst.download
         assert True
-                
+
     def test_download_presence(self):
         for module in self.instrument_modules:
             yield (self.check_download_presence, module)
 
     def check_module_tdates(self, module):
         info = module.test_dates
-        check = []        
+        check = []
         for sat_id in info.keys():
             for tag in info[sat_id].keys():
-                check.append(isinstance(info[sat_id][tag], pysat.datetime))             
+                check.append(isinstance(info[sat_id][tag], pysat.datetime))
         assert np.all(check)
 
     def check_download(self, inst):
         from unittest.case import SkipTest
         import os
-        
+
         start = inst.test_dates[inst.sat_id][inst.tag]
         # print (start)
         try:
@@ -258,32 +258,32 @@ class TestInstrumentQualifier():
             f = partial(self.check_module_tdates, inst)
             f.description = ' '.join(('Checking for test_dates information attached to module: ', inst.platform, inst.name, inst.tag, inst.sat_id))
             yield (f,)
-            
+
             f = partial(self.check_download, inst)
             f.description = ' '.join(('Checking download routine functionality for module: ', inst.platform, inst.name, inst.tag, inst.sat_id))
             yield (f,)
-            
+
             # make sure download was successful
             if len(inst.files.files) > 0:
                 f = partial(self.check_load, inst, fuzzy=True)
                 f.description = ' '.join(('Checking load routine functionality for module: ', inst.platform, inst.name, inst.tag, inst.sat_id))
                 yield (f,)
-                
+
                 inst.clean_level = 'none'
                 f = partial(self.check_load, inst)
                 f.description = ' '.join(('Checking load routine functionality for module with clean level "none": ', inst.platform, inst.name, inst.tag, inst.sat_id))
                 yield (f,)
-    
+
                 inst.clean_level = 'dirty'
                 f = partial(self.check_load, inst, fuzzy=True)
                 f.description = ' '.join(('Checking load routine functionality for module with clean level "dirty": ', inst.platform, inst.name, inst.tag, inst.sat_id))
                 yield (f,)
-                
+
                 inst.clean_level = 'dusty'
                 f = partial(self.check_load, inst, fuzzy=True)
                 f.description = ' '.join(('Checking load routine functionality for module with clean level "dusty": ', inst.platform, inst.name, inst.tag, inst.sat_id))
                 yield (f,)
-    
+
                 inst.clean_level = 'clean'
                 f = partial(self.check_load, inst, fuzzy=True)
                 f.description = ' '.join(('Checking load routine functionality for module with clean level "clean": ', inst.platform, inst.name, inst.tag, inst.sat_id))
@@ -297,16 +297,14 @@ class TestInstrumentQualifier():
 
 
     # Optional support
-    
+
     # directory_format string
-    
+
     # multiple file days
-    
+
     # orbit information
-    
+
         # self.directory_format = None
         # self.file_format = None
         # self.multi_file_day = False
-        # self.orbit_info = None                
-    
-    
+        # self.orbit_info = None

--- a/pysat/tests/test_sw.py
+++ b/pysat/tests/test_sw.py
@@ -49,9 +49,6 @@ class TestSWKp():
             if len(self.combine[kk].files.files) == 0:
                 self.download = False
 
-        if (os.environ.get('TRAVIS') == 'true'):
-            self.download = False
-
     def teardown(self):
         """Runs after every method to clean up previous testing."""
         del self.testInst, self.testMeta, self.combine, self.download

--- a/pysat/tests/test_sw.py
+++ b/pysat/tests/test_sw.py
@@ -8,15 +8,16 @@ import pandas as pds
 import pysat
 from pysat.instruments import sw_kp, sw_f107, sw_methods
 
+
 class TestSWKp():
     def setup(self):
         """Runs before every method to create a clean testing setup"""
         # Load a test instrument
         self.testInst = pysat.Instrument()
         self.testInst.data = pds.DataFrame({'Kp': np.arange(0, 4, 1.0/3.0)},
-                                             index=[pysat.datetime(2009, 1, 1)
-                                                    + pds.DateOffset(hours=3*i)
-                                                    for i in range(12)])
+                                           index=[pysat.datetime(2009, 1, 1)
+                                                  + pds.DateOffset(hours=3*i)
+                                                  for i in range(12)])
         self.testInst.meta = pysat.Meta()
         self.testInst.meta.__setitem__('Kp', {self.testInst.meta.fill_label:
                                               np.nan})
@@ -47,6 +48,9 @@ class TestSWKp():
 
             if len(self.combine[kk].files.files) == 0:
                 self.download = False
+
+        if (os.environ.get('TRAVIS') == 'true'):
+            self.download = False
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
@@ -85,7 +89,7 @@ class TestSWKp():
         if np.isnan(self.testInst['Kp'][0]):
             assert np.isnan(self.testInst['3hr_ap'][0])
             assert np.isnan( \
-                    self.testInst.meta['3hr_ap'][self.testInst.meta.fill_label])
+                self.testInst.meta['3hr_ap'][self.testInst.meta.fill_label])
         else:
             assert self.testInst['Kp'][0] == self.testInst['3hr_ap'][0]
             assert(self.testInst.meta['3hr_ap'][self.testInst.meta.fill_label]
@@ -151,7 +155,7 @@ class TestSWKp():
 
     def test_combine_kp_none(self):
         """ Test combine_kp failure when no input is provided"""
-        
+
         assert_raises(ValueError, sw_methods.combine_kp)
 
     def test_combine_kp_one(self):
@@ -220,7 +224,8 @@ class TestSWKp():
         # Fill value is defined by combine
         assert(kp_inst.meta['Kp'][kp_inst.meta.fill_label] ==
                self.combine['fill_val'])
-        assert len(kp_inst['Kp'][kp_inst['Kp']==self.combine['fill_val']]) == 0
+        assert len(kp_inst['Kp'][kp_inst['Kp'] ==
+                   self.combine['fill_val']]) == 0
 
         del kp_inst
 
@@ -294,9 +299,9 @@ class TestSWF107():
         # Load a test instrument
         self.testInst = pysat.Instrument()
         self.testInst.data = pds.DataFrame({'f107': np.linspace(70, 200, 160)},
-                                             index=[pysat.datetime(2009, 1, 1)
-                                                    + pds.DateOffset(days=i)
-                                                    for i in range(160)])
+                                           index=[pysat.datetime(2009, 1, 1)
+                                                  + pds.DateOffset(days=i)
+                                                  for i in range(160)])
 
         # Set combination testing input
         self.today = dt.datetime.today().replace(hour=0, minute=0, second=0,
@@ -329,7 +334,7 @@ class TestSWF107():
 
     def test_combine_f107_none(self):
         """ Test combine_f107 failure when no input is provided"""
-        
+
         assert_raises(TypeError, sw_methods.combine_f107)
 
     def test_combine_f107_no_time(self):
@@ -402,9 +407,9 @@ class TestSWF107():
     def test_calc_f107a_high_rate(self):
         """ Test the calc_f107a routine with sub-daily data"""
         self.testInst.data = pds.DataFrame({'f107': np.linspace(70, 200, 3840)},
-                                             index=[pysat.datetime(2009, 1, 1)
-                                                    + pds.DateOffset(hours=i)
-                                                    for i in range(3840)])
+                                           index=[pysat.datetime(2009, 1, 1)
+                                                  + pds.DateOffset(hours=i)
+                                                  for i in range(3840)])
         sw_f107.calc_f107a(self.testInst, f107_name='f107', f107a_name='f107a')
 
         # Assert that new data and metadata exist
@@ -423,9 +428,9 @@ class TestSWF107():
         """ Test the calc_f107a routine with some daily data missing"""
 
         self.testInst.data = pds.DataFrame({'f107': np.linspace(70, 200, 160)},
-                                             index=[pysat.datetime(2009, 1, 1)
-                                                    + pds.DateOffset(days=2*i+1)
-                                                    for i in range(160)])
+                                           index=[pysat.datetime(2009, 1, 1)
+                                                  + pds.DateOffset(days=2*i+1)
+                                                  for i in range(160)])
         sw_f107.calc_f107a(self.testInst, f107_name='f107', f107a_name='f107a')
 
         # Assert that new data and metadata exist
@@ -450,9 +455,9 @@ class TestSWAp():
         self.testInst = pysat.Instrument()
         self.testInst.data = pds.DataFrame({'3hr_ap': [0, 2, 3, 4, 5, 6, 7, 9,
                                                        12, 15]},
-                                             index=[pysat.datetime(2009, 1, 1)
-                                                    + pds.DateOffset(hours=3*i)
-                                                    for i in range(10)])
+                                           index=[pysat.datetime(2009, 1, 1)
+                                                  + pds.DateOffset(hours=3*i)
+                                                  for i in range(10)])
         self.testInst.meta = pysat.Meta()
         self.meta_dict = {self.testInst.meta.units_label: '',
                           self.testInst.meta.name_label: 'ap',
@@ -466,7 +471,6 @@ class TestSWAp():
                           self.testInst.meta.fill_label: np.nan,
                           self.testInst.meta.notes_label: 'test ap'}
         self.testInst.meta.__setitem__('3hr_ap', self.meta_dict)
-
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
@@ -489,7 +493,8 @@ class TestSWAp():
     def test_calc_daily_Ap_bad_3hr(self):
         """ Test daily Ap calculation with bad input key"""
 
-        assert_raises(ValueError, sw_methods.calc_daily_Ap, self.testInst, "no")
+        assert_raises(ValueError, sw_methods.calc_daily_Ap, self.testInst,
+                      "no")
 
     def test_calc_daily_Ap_bad_daily(self):
         """ Test daily Ap calculation with bad output key"""

--- a/pysat/tests/test_sw.py
+++ b/pysat/tests/test_sw.py
@@ -44,6 +44,7 @@ class TestSWKp():
                 self.combine[kk].download(start=self.combine['start'],
                                           stop=self.combine['stop'])
             except:
+                self.download = False
                 pass
 
             if len(self.combine[kk].files.files) == 0:


### PR DESCRIPTION
Partial fix for #79.  Replaces `ftplib` with `requests` in cdaweb_methods.download to allow access to cdaweb data via HTTPS.  Allows for future implementation of restful web services with cdaweb server. 