### PR TITLE
Added OCB testing option

### DIFF
--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -99,20 +99,25 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     month = int(parts[1])
     day = int(parts[2][0:2])
 
+    # Specify the date tag locally and determine the desired date range
+    date_tag = '' if tag not in tags
+
     date = pysat.datetime(yr, month, day)
     if sim_multi_file_right:
-        root_date = root_date or test_dates[tag][sat_id] + \
+        root_date = root_date or test_dates[date_tag][sat_id] + \
             pds.DateOffset(hours=12)
         data_date = date + pds.DateOffset(hours=12)
     elif sim_multi_file_left:
-        root_date = root_date or test_dates[tag][sat_id] - \
+        root_date = root_date or test_dates[date_tag][sat_id] - \
             pds.DateOffset(hours=12)
         data_date = date - pds.DateOffset(hours=12)
     else:
-        root_date = root_date or test_dates[tag][sat_id]
+        root_date = root_date or test_dates[date_tag][sat_id]
         data_date = date
 
-    num = 86400 if tag in ['', 'ocb'] else int(tag)
+    # The tag can be used to specify the number of indexes to load, if
+    # using the default testing object
+    num = 86400 if tag in tags else int(tag)
     num_array = np.arange(num)
     uts = num_array
     data = pysat.DataFrame(uts, columns=['uts'])
@@ -125,7 +130,7 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     data['mlt'] = mlt
     
     # fake orbit number
-    fake_delta = date  - (test_dates[tag][sat_id] - pds.DateOffset(years=1))
+    fake_delta = date  - (test_dates[date_tag][sat_id]-pds.DateOffset(years=1))
     fake_uts_root = fake_delta.total_seconds()
 
     data['orbit_num'] = ((fake_uts_root + num_array) / 5820.0).astype(int)
@@ -172,8 +177,9 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     """Produce a fake list of files spanning a year"""
 
     # Determine the appropriate date range for the fake files
-    start = test_dates[tag][sat_id] - pds.DateOffset(years=1)
-    stop = test_dates[tag][sat_id] + pds.DateOffset(days=364)
+    date_tag = '' if tag not in tags
+    start = test_dates[date_tag][sat_id] - pds.DateOffset(years=1)
+    stop = test_dates[date_tag][sat_id] + pds.DateOffset(days=364)
     index = pds.date_range(start, stop)
 
     # Create the list of fake filenames

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -4,11 +4,12 @@ Produces fake instrument data for testing.
 """
 from __future__ import print_function
 from __future__ import absolute_import
-
+import functools
 import os
 
 import pandas as pds
 import numpy as np
+
 import pysat
 
 # pysat required parameters
@@ -16,15 +17,11 @@ platform = 'pysat'
 name = 'testing'
 
 # dictionary of data 'tags' and corresponding description
-tags = {'': 'Regular testing data set',
-        'ocb': 'Testing data set for OCBpy'}
+tags = {'': 'Regular testing data set'}
 
 # dictionary of satellite IDs, list of corresponding tags
-sat_ids = {'': [''],
-           'ocb': ['image', 'ampere']}
-test_dates = {'': {'': pysat.datetime(2009,1,1)},
-              'ocb': {'image': pysat.datetime(2000, 5, 5),
-                      'ampere': pysat.datetime(2010, 1, 1),}}
+sat_ids = {'': ['']}
+test_dates = {'': {'': pysat.datetime(2009,1,1)}}
 
 meta = pysat.Meta()
 meta['uts'] = {'units': 's', 'long_name': 'Universal Time', 'custom': False}
@@ -73,26 +70,73 @@ meta['orbit_num'] = {'units': '',
                      'fill': np.nan,
                      'scale': 'linear'}
 
-meta['longitude'] = {'units':'degrees', 'long_name':'Longitude'} 
-meta['latitude'] = {'units':'degrees', 'long_name':'Latitude'} 
-meta['dummy1'] = {'units':'', 'long_name':'dummy1'}
-meta['dummy2'] = {'units':'', 'long_name':'dummy2'}
-meta['dummy3'] = {'units':'', 'long_name':'dummy3'}
-meta['dummy4'] = {'units':'', 'long_name':'dummy4'}
-meta['string_dummy'] = {'units':'', 'long_name':'string_dummy'}
-meta['unicode_dummy'] = {'units':'', 'long_name':'unicode_dummy'}
-meta['int8_dummy'] = {'units':'', 'long_name':'int8_dummy'}
-meta['int16_dummy'] = {'units':'', 'long_name':'int16_dummy'}
-meta['int32_dummy'] = {'units':'', 'long_name':'int32_dummy'}
-meta['int64_dummy'] = {'units':'', 'long_name':'int64_dummy'}
+meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'} 
+meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'} 
+meta['dummy1'] = {'units': '', 'long_name': 'dummy1'}
+meta['dummy2'] = {'units': '', 'long_name': 'dummy2'}
+meta['dummy3'] = {'units': '', 'long_name': 'dummy3'}
+meta['dummy4'] = {'units': '', 'long_name': 'dummy4'}
+meta['string_dummy'] = {'units': '', 'long_name': 'string_dummy'}
+meta['unicode_dummy'] = {'units': '', 'long_name': 'unicode_dummy'}
+meta['int8_dummy'] = {'units': '', 'long_name':' int8_dummy'}
+meta['int16_dummy'] = {'units': '', 'long_name': 'int16_dummy'}
+meta['int32_dummy'] = {'units': '', 'long_name': 'int32_dummy'}
+meta['int64_dummy'] = {'units': '', 'long_name': 'int64_dummy'}
 
 
         
 def init(self):
-    self.new_thing=True        
-                
+    """ Initialization function
+
+    Parameters
+    ----------
+    file_date_range : (pds.date_range)
+        Optional keyword argument that specifies the range of dates for which
+        test files will be created
+
+    """
+    self.new_thing=True
+
+    if 'file_date_range' in self.kwargs:
+        # set list files routine to desired date range
+        # attach to the instrument object
+        self._list_rtn = functools.partial(list_files, \
+                                file_date_range=self.kwargs['file_date_range'])
+        self.files.refresh()
+
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
-         sim_multi_file_left=False, root_date=None):
+         sim_multi_file_left=False, root_date=None, file_date_range=None):
+    """ Loads the test files
+
+    Parameters
+    ----------
+    fnames : (list)
+        List of filenames
+    tag : (str or NoneType)
+        Instrument tag (accepts '' or a number (i.e., '10'), which specifies
+        the number of times to include in the test instrument)
+    sat_id : (str or NoneType)
+        Instrument satellite ID (accepts '')
+    sim_multi_file_right : (boolean)
+        Adjusts date range to be 12 hours in the future or twelve hours beyond
+        root_date (default=False)
+    sim_multi_file_left : (boolean)
+        Adjusts date range to be 12 hours in the past or twelve hours before
+        root_date (default=False)
+    root_date : (NoneType)
+        Optional central date, uses test_dates if not specified.  (default=None)
+    file_date_range : (pds.date_range or NoneType)
+        Range of dates for files or None, if this optional arguement is not used
+        (default=None)
+
+    Returns
+    -------
+    data : (pds.DataFrame)
+        Testing data
+    meta : (pysat.Meta)
+        Metadataxs
+
+    """
     # create an artifical satellite data set
     parts = os.path.split(fnames[0])[-1].split('-')
     yr = int(parts[0])
@@ -100,37 +144,35 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     day = int(parts[2][0:2])
 
     # Specify the date tag locally and determine the desired date range
-    date_tag = '' if tag not in tags else tag
-
     date = pysat.datetime(yr, month, day)
     if sim_multi_file_right:
-        root_date = root_date or test_dates[date_tag][sat_id] + \
+        root_date = root_date or test_dates[''][''] + \
             pds.DateOffset(hours=12)
         data_date = date + pds.DateOffset(hours=12)
     elif sim_multi_file_left:
-        root_date = root_date or test_dates[date_tag][sat_id] - \
+        root_date = root_date or test_dates[''][''] - \
             pds.DateOffset(hours=12)
         data_date = date - pds.DateOffset(hours=12)
     else:
-        root_date = root_date or test_dates[date_tag][sat_id]
+        root_date = root_date or test_dates['']['']
         data_date = date
 
     # The tag can be used to specify the number of indexes to load, if
     # using the default testing object
-    num = 86400 if tag in tags else int(tag)
+    num = 86400 if tag in tags.keys() else int(tag)
     num_array = np.arange(num)
     uts = num_array
     data = pysat.DataFrame(uts, columns=['uts'])
 
-    # need to create simple orbits here. Have start of first orbit 
-    # at 2009,1, 0 UT. 14.84 orbits per day	
-    time_delta = date  - root_date
+    # need to create simple orbits here. Have start of first orbit default
+    # to 1 Jan 2009, 00:00 UT. 14.84 orbits per day	
+    time_delta = date - root_date
     uts_root = np.mod(time_delta.total_seconds(), 5820)
     mlt = np.mod(uts_root + num_array, 5820) * (24.0 / 5820.0)
     data['mlt'] = mlt
     
     # fake orbit number
-    fake_delta = date  - (test_dates[date_tag][sat_id]-pds.DateOffset(years=1))
+    fake_delta = date  - (test_dates['']['']-pds.DateOffset(years=1))
     fake_uts_root = fake_delta.total_seconds()
 
     data['orbit_num'] = ((fake_uts_root + num_array) / 5820.0).astype(int)
@@ -173,14 +215,37 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     return data, meta.copy()
 
 
-def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
-    """Produce a fake list of files spanning a year"""
+def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
+               file_date_range=None):
+    """Produce a fake list of files spanning a year
+
+    Parameters
+    ----------
+    tag : (str)
+        pysat instrument tag (default=None)
+    sat_id : (str)
+        pysat satellite ID tag (default=None)
+    data_path : (str)
+        pysat data path (default=None)
+    format_str : (str)
+        file format string (default=None)
+    file_date_range : (pds.date_range)
+        File date range (default=None)
+
+    Returns
+    -------
+    Series of filenames indexed by file time
+
+    """
 
     # Determine the appropriate date range for the fake files
-    date_tag = '' if tag not in tags else tag
-    start = test_dates[date_tag][sat_id] - pds.DateOffset(years=1)
-    stop = test_dates[date_tag][sat_id] + pds.DateOffset(days=364)
-    index = pds.date_range(start, stop)
+    if file_date_range is None:
+        start = test_dates[''][''] - pds.DateOffset(years=1)
+        stop = test_dates[''][''] + pds.DateOffset(years=2) \
+            - pds.DateOffset(days=1)
+        file_date_range = pds.date_range(start, stop)
+
+    index = file_date_range
 
     # Create the list of fake filenames
     names = [data_path + date.strftime('%Y-%m-%d') + '.nofile'
@@ -190,4 +255,5 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
 
 def download(date_array, tag, sat_id, data_path=None, user=None, password=None):
+    """ Download routine, not used since files are created locally"""
     pass

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -100,7 +100,7 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     day = int(parts[2][0:2])
 
     # Specify the date tag locally and determine the desired date range
-    date_tag = '' if tag not in tags
+    date_tag = '' if tag not in tags else tag
 
     date = pysat.datetime(yr, month, day)
     if sim_multi_file_right:
@@ -177,7 +177,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     """Produce a fake list of files spanning a year"""
 
     # Determine the appropriate date range for the fake files
-    date_tag = '' if tag not in tags
+    date_tag = '' if tag not in tags else tag
     start = test_dates[date_tag][sat_id] - pds.DateOffset(years=1)
     stop = test_dates[date_tag][sat_id] + pds.DateOffset(days=364)
     index = pds.date_range(start, stop)


### PR DESCRIPTION
This pull requests makes it possible to test the new pysat branch of OCBpy.

- PEP8 changes
- Added OCB tag and sat_id's for the different OCB instruments with appropriate date ranges
- Changed fake file construction to have the same range of dates, but based off of the date provided in test_dates.