### PR TITLE
Pyglow install update / Travis streamline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - pip install coveralls
   - pip install future
   - pip install matplotlib
+  - pip install netCDF4
   - pip install pysatCDF >/dev/null
   # install pyglow, space science models
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ python:
 sudo: false
 
 cache: pip
-cache:		
-   directories:		
+cache:
+   directories:
       - ../pyglow_cache
- 
+
 addons:
   apt:
     packages:
@@ -18,53 +18,28 @@ addons:
 # Setup anaconda
 before_install:
   #- apt-get update
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q --yes conda
-  # Useful for debugging any issues with conda
-  - conda info -a
-  # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION atlas numpy scipy matplotlib nose pandas statsmodels coverage netCDF4 ipython xarray
+  - pip install coveralls
+  - pip install future
+  - pip install matplotlib
+  - pip install pysatCDF >/dev/null
+  # install pyglow, space science models
+  - cd ..
+  - echo 'cloning pyglow'
+  - git clone https://github.com/timduly4/pyglow.git >/dev/null
+  - echo 'installing pyglow'
+  - cd ./pyglow
+  - make -C src/pyglow/models source >/dev/null
+  - python setup.py install >/dev/null
+  - cd ..
 
 # command to install dependencies
 install:
-  # Coverage packages are on my binstar channel
-  # - conda install --yes -c dan_blanchard python-coveralls nose-cov
   - source activate test-environment
-  - pip install coveralls
-  - pip install future
-  - pip install pysatCDF >/dev/null
-    # install pyglow, space science models
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      travis_wait 30 pip install ipdb --user;
-      cd ..;
-    fi
-  - pwd
-  - ls
-    
-
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      cd ..;
-      echo 'cloning pyglow';
-      travis_wait 50 git clone https://github.com/timduly4/pyglow.git;
-      echo 'installing pyglow';
-      cd ./pyglow;
-      travis_wait 50 make -C src/pyglow/models source >/dev/null;
-      travis_wait 50 python setup.py install --user >/dev/null;
-      cd ..; 
-    fi
   # install pysat
   - cd /home/travis/build/rstoneback/pysat
-  - "python setup.py install"
+  - python setup.py install
 # command to run tests
 script:
-  - nosetests -vs --with-coverage --cover-package=pysat
+ - nosetests -vs --with-coverage --cover-package=pysat
 after_success:
-  coveralls
+ - coveralls

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -18,15 +18,12 @@ import numpy as np
 import sys
 import importlib
 
-exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps', 
+exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps', 'cosmic2013_gps',
                 'icon_euv', 'icon_ivm']
 # dict, keyed by pysat instrument, with a list of usernames and passwords
 user_download_dict = {'supermag_magnetometer':['rstoneback', None]}
 
-if sys.version_info[0] >= 3:
-    # TODO Remove when pyglow works in python 3
-    exclude_list.append('pysat_sgp4')
-    
+
 def safe_data_dir():
     saved_path = pysat.data_dir
     if saved_path is '':
@@ -36,8 +33,8 @@ def safe_data_dir():
 def init_func_external(self):
     """Iterate through and create all of the test Instruments needed.
        Only want to do this once.
-       
-    """    
+
+    """
 
     # names of all the instrument modules
     instrument_names = pysat.instruments.__all__
@@ -49,11 +46,11 @@ def init_func_external(self):
     self.instruments = []
     self.instrument_modules = []
 
-    # create temporary directory  
+    # create temporary directory
     dir_name = tempfile.mkdtemp()
     saved_path = safe_data_dir()
-    pysat.utils.set_data_dir(dir_name, store=False)    
-        
+    pysat.utils.set_data_dir(dir_name, store=False)
+
     for name in instrument_names:
         try:
             module = importlib.import_module(''.join(('.', name)), package='pysat.instruments')
@@ -68,26 +65,26 @@ def init_func_external(self):
             except AttributeError:
                 info = {}
                 info[''] = {'':pysat.datetime(2009,1,1)}
-                module.test_dates = info            
-            for sat_id in info.keys() :  
+                module.test_dates = info
+            for sat_id in info.keys() :
                 for tag in info[sat_id].keys():
                     try:
-                        inst = pysat.Instrument(inst_module=module, 
-                                                tag=tag, 
+                        inst = pysat.Instrument(inst_module=module,
+                                                tag=tag,
                                                 sat_id=sat_id,
-                                                temporary_file_list=True) 
+                                                temporary_file_list=True)
                         inst.test_dates = module.test_dates
                         self.instruments.append(inst)
                         self.instrument_modules.append(module)
                     except:
                         pass
     pysat.utils.set_data_dir(saved_path, store=False)
-            
+
 init_inst = None
 init_mod = None
-        
+
 class TestInstrumentQualifier():
-    
+
     def __init__(self):
         """Iterate through and create all of the test Instruments needed"""
         global init_inst
@@ -100,7 +97,7 @@ class TestInstrumentQualifier():
         else:
             self.instruments = init_inst
             self.instrument_modules = init_mod
-        
+
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         pass
@@ -112,11 +109,11 @@ class TestInstrumentQualifier():
     def check_module_loadable(self, module, tag, sat_id):
         a = pysat.Instrument(inst_module=module, tag=tag, sat_id=sat_id)
         assert True
-        
+
     def check_module_importable(self, name):
         module = importlib.import_module(''.join(('.', name)), package='pysat.instruments')
         assert True
-        
+
     def check_module_info(self, module):
         platform = module.platform
         name = module.name
@@ -130,16 +127,16 @@ class TestInstrumentQualifier():
         check.append(isinstance(sat_ids, dict))
         # that contains lists
         assert np.all(check)
-    
+
     def test_modules_loadable(self):
         instrument_names = pysat.instruments.__all__
         self.instruments = []
-    
+
         for name in instrument_names:
             f = partial(self.check_module_importable, name)
             f.description = ' '.join(('Checking importability for module:', name))
             yield (f,)
-            
+
             try:
                 module = importlib.import_module(''.join(('.', name)), package='pysat.instruments')
             except ImportError:
@@ -155,8 +152,8 @@ class TestInstrumentQualifier():
                     info = module.test_dates
                 except AttributeError:
                     info = {}
-                    info[''] = {'':'failsafe'}            
-                for sat_id in info.keys() :  
+                    info[''] = {'':'failsafe'}
+                for sat_id in info.keys() :
                     for tag in info[sat_id].keys():
                         f = partial(self.check_module_loadable, module, tag, sat_id)
                         f.description = ' '.join(('Checking pysat.Instrument instantiation for module:', name, 'tag:', tag, 'sat id:', sat_id))
@@ -166,43 +163,43 @@ class TestInstrumentQualifier():
     def check_load_presence(self, inst):
         _ = inst.load
         assert True
-                
+
     def test_load_presence(self):
         for module in self.instrument_modules:
             f = partial(self.check_load_presence, module)
             f.description = ' '.join(('Checking for load routine for module: ', module.platform, module.name))
             yield (f,)
-            
+
     def check_list_files_presence(self, module):
         _ = module.list_files
         assert True
-                
+
     def test_list_files_presence(self):
         for module in self.instrument_modules:
             f = partial(self.check_list_files_presence, module)
             f.description = ' '.join(('Checking for list_files routine for module: ', module.platform, module.name))
             yield (f,)
-            
+
     def check_download_presence(self, inst):
         _ = inst.download
         assert True
-                
+
     def test_download_presence(self):
         for module in self.instrument_modules:
             yield (self.check_download_presence, module)
 
     def check_module_tdates(self, module):
         info = module.test_dates
-        check = []        
+        check = []
         for sat_id in info.keys():
             for tag in info[sat_id].keys():
-                check.append(isinstance(info[sat_id][tag], pysat.datetime))             
+                check.append(isinstance(info[sat_id][tag], pysat.datetime))
         assert np.all(check)
 
     def check_download(self, inst):
         from unittest.case import SkipTest
         import os
-        
+
         start = inst.test_dates[inst.sat_id][inst.tag]
         # print (start)
         try:
@@ -258,32 +255,32 @@ class TestInstrumentQualifier():
             f = partial(self.check_module_tdates, inst)
             f.description = ' '.join(('Checking for test_dates information attached to module: ', inst.platform, inst.name, inst.tag, inst.sat_id))
             yield (f,)
-            
+
             f = partial(self.check_download, inst)
             f.description = ' '.join(('Checking download routine functionality for module: ', inst.platform, inst.name, inst.tag, inst.sat_id))
             yield (f,)
-            
+
             # make sure download was successful
             if len(inst.files.files) > 0:
                 f = partial(self.check_load, inst, fuzzy=True)
                 f.description = ' '.join(('Checking load routine functionality for module: ', inst.platform, inst.name, inst.tag, inst.sat_id))
                 yield (f,)
-                
+
                 inst.clean_level = 'none'
                 f = partial(self.check_load, inst)
                 f.description = ' '.join(('Checking load routine functionality for module with clean level "none": ', inst.platform, inst.name, inst.tag, inst.sat_id))
                 yield (f,)
-    
+
                 inst.clean_level = 'dirty'
                 f = partial(self.check_load, inst, fuzzy=True)
                 f.description = ' '.join(('Checking load routine functionality for module with clean level "dirty": ', inst.platform, inst.name, inst.tag, inst.sat_id))
                 yield (f,)
-                
+
                 inst.clean_level = 'dusty'
                 f = partial(self.check_load, inst, fuzzy=True)
                 f.description = ' '.join(('Checking load routine functionality for module with clean level "dusty": ', inst.platform, inst.name, inst.tag, inst.sat_id))
                 yield (f,)
-    
+
                 inst.clean_level = 'clean'
                 f = partial(self.check_load, inst, fuzzy=True)
                 f.description = ' '.join(('Checking load routine functionality for module with clean level "clean": ', inst.platform, inst.name, inst.tag, inst.sat_id))
@@ -297,16 +294,14 @@ class TestInstrumentQualifier():
 
 
     # Optional support
-    
+
     # directory_format string
-    
+
     # multiple file days
-    
+
     # orbit information
-    
+
         # self.directory_format = None
         # self.file_format = None
         # self.multi_file_day = False
-        # self.orbit_info = None                
-    
-    
+        # self.orbit_info = None

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -35,7 +35,7 @@ def test_getyrdoy_leap_year():
     """Test the date to year, day of year code functionality (leap_year)"""
     date = pds.datetime(2008,12,31)
     yr, doy = pysat.utils.getyrdoy(date)
-    assert ((yr == 2008) & (doy == 366)) 
+    assert ((yr == 2008) & (doy == 366))
 
 #----------------------------------
 # test netCDF export file support
@@ -65,16 +65,16 @@ def remove_files(inst):
 
 class TestBasics():
     def setup(self):
-        """Runs before every method to create a clean testing setup."""        
+        """Runs before every method to create a clean testing setup."""
         # store current pysat directory
         self.data_path = pysat.data_dir
-        
-        # create temporary directory  
+
+        # create temporary directory
         dir_name = tempfile.mkdtemp()
         pysat.utils.set_data_dir(dir_name, store=False)
 
-        self.testInst = pysat.Instrument(inst_module=pysat.instruments.pysat_testing, 
-                                        clean_level='clean')
+        self.testInst = pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
+                                         clean_level='clean')
         # create testing directory
         prep_dir(self.testInst)
 
@@ -106,7 +106,7 @@ class TestBasics():
             pass
         del self.testInst, self.test_angles, self.test_nan, self.circ_kwargs
         del self.deg_units, self.dist_units, self.vel_units
-    
+
     def test_basic_writing_and_reading_netcdf4_default_format(self):
         # create a bunch of files by year and doy
         from unittest.case import SkipTest
@@ -114,8 +114,8 @@ class TestBasics():
             import netCDF4
         except ImportError:
             raise SkipTest
-  
-        prep_dir(self.testInst)            
+
+        prep_dir(self.testInst)
         outfile = os.path.join(self.testInst.files.data_path, 'test_ncdf.nc')
         self.testInst.load(2009,1)
         self.testInst.to_netcdf4(outfile)
@@ -182,7 +182,7 @@ class TestBasics():
             import netCDF4
         except ImportError:
             raise SkipTest
-        test_inst = pysat.Instrument('pysat', 'testing2d')    
+        test_inst = pysat.Instrument('pysat', 'testing2d')
         prep_dir(test_inst)
         outfile = os.path.join(test_inst.files.data_path, 'test_ncdf.nc')
         test_inst.load(2009,1)
@@ -192,15 +192,15 @@ class TestBasics():
         loaded_inst = loaded_inst.reindex_axis(sorted(loaded_inst.columns),
                                                axis=1)
         prep_dir(test_inst)
-        
+
         # test Series of DataFrames
         test_list = []
         #print (loaded_inst.columns)
         for frame1, frame2 in zip(test_inst.data['profiles'],
                                   loaded_inst['profiles']):
             test_list.append(np.all((frame1 == frame2).all()))
-        loaded_inst.drop('profiles', inplace=True, axis=1) 
-        test_inst.data.drop('profiles', inplace=True, axis=1)   
+        loaded_inst.drop('profiles', inplace=True, axis=1)
+        test_inst.data.drop('profiles', inplace=True, axis=1)
 
         # second series of frames
         for frame1, frame2 in zip(test_inst.data['alt_profiles'],
@@ -224,7 +224,7 @@ class TestBasics():
 
         loaded_inst.drop('series_profiles', inplace=True, axis=1)
         test_inst.data.drop('series_profiles', inplace=True, axis=1)
-        
+
         assert(np.all((test_inst.data == loaded_inst).all()))
         assert np.all(test_list)
 
@@ -255,7 +255,7 @@ class TestBasics():
             test_list.append(np.all((frame1 == frame2).all()))
         loaded_inst.drop('profiles', inplace=True, axis=1)
         test_inst.data.drop('profiles', inplace=True, axis=1)
-        
+
         # second series of frames
         for frame1, frame2 in zip(test_inst.data['alt_profiles'],
                                   loaded_inst['alt_profiles']):
@@ -270,11 +270,11 @@ class TestBasics():
             # print frame1, frame2
         loaded_inst.drop('series_profiles', inplace=True, axis=1)
         test_inst.data.drop('series_profiles', inplace=True, axis=1)
-        
+
         assert (np.all((test_inst.data == loaded_inst).all()))
         # print (test_list)
         assert np.all(test_list)
-        
+
     # def test_basic_writing_and_reading_netcdf4_multiple_formats(self):
     #     # create a bunch of files by year and doy
     #     from unittest.case import SkipTest
@@ -339,8 +339,8 @@ class TestBasics():
         else:
             check3 = True
 
-        assert check1 & check2 & check3        
-                        
+        assert check1 & check2 & check3
+
     def test_initial_pysat_load(self):
         import shutil
         saved = False
@@ -351,9 +351,9 @@ class TestBasics():
             saved = True
         except:
             pass
-            
+
         re_load(pysat)
-        
+
         try:
             if saved:
                 # remove directory, trying to be careful
@@ -364,7 +364,7 @@ class TestBasics():
             pass
 
         assert True
-    
+
     def test_circmean(self):
         """ Test custom circular mean."""
         from scipy import stats
@@ -462,7 +462,7 @@ class TestBasics():
 
     def test_scale_units_dist(self):
         """Test scale_units for distances """
-        
+
         for out_unit in self.dist_units:
             scale = pysat.utils.scale_units(out_unit, "m")
 
@@ -475,7 +475,7 @@ class TestBasics():
 
     def test_scale_units_vel(self):
         """Test scale_units for velocities """
-        
+
         for out_unit in self.vel_units:
             scale = pysat.utils.scale_units(out_unit, "m/s")
 


### PR DESCRIPTION
Fix for #154.

- Updated `.travis.yml` to install latest version of `pyglow` (python 3 compatible). 
- Streamlined `.travis.yml` and removed python version checks since not needed with `pyglow` update.
- Updated `test_instruments.py` to run sgp4 tests in python 3.6.  Should result in an increase in coverage.

When combined with final version of #143, all Travis CI tests should be passing.

