### PR TITLE
Updates to pysat testing instruments

### DIFF
--- a/pysat/instruments/pysat_testadd1.py
+++ b/pysat/instruments/pysat_testadd1.py
@@ -31,6 +31,36 @@ def init(self):
 
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
+    """ Loads the test files
+
+    Parameters
+    ----------
+    fnames : (list)
+        List of filenames
+    tag : (str or NoneType)
+        Instrument tag (accepts '' or a number (i.e., '10'), which specifies
+        the number of times to include in the test instrument)
+    sat_id : (str or NoneType)
+        Instrument satellite ID (accepts '')
+    sim_multi_file_right : (boolean)
+        Adjusts date range to be 12 hours in the future or twelve hours beyond
+        root_date (default=False)
+    sim_multi_file_left : (boolean)
+        Adjusts date range to be 12 hours in the past or twelve hours before
+        root_date (default=False)
+    root_date : (NoneType)
+        Optional central date, uses test_dates if not specified.
+        (default=None)
+
+    Returns
+    -------
+    data : (pds.DataFrame)
+        Testing data
+    meta : (pysat.Meta)
+        Metadataxs
+
+    """
+
     # create an artifical satellite data set
     parts = fnames[0].split('-')
     yr = int('20' + parts[-1][0:2])

--- a/pysat/instruments/pysat_testadd1.py
+++ b/pysat/instruments/pysat_testadd1.py
@@ -31,18 +31,18 @@ def init(self):
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
     # create an artifical satellite data set
-    parts = fnames[0].split('/')
-    yr = int('20'+parts[-1][0:2])
+    parts = fnames[0].split('-')
+    yr = int('20' + parts[-1][0:2])
     month = int(parts[-3])
     day = int(parts[-2])
 
     date = pysat.datetime(yr, month, day)
     if sim_multi_file_right:
         root_date = root_date or pysat.datetime(2009, 1, 1, 12)
-        data_date = date+pds.DateOffset(hours=12)
+        data_date = date + pds.DateOffset(hours=12)
     elif sim_multi_file_left:
         root_date = root_date or pysat.datetime(2008, 12, 31, 12)
-        data_date = date-pds.DateOffset(hours=12)
+        data_date = date - pds.DateOffset(hours=12)
     else:
         root_date = root_date or pysat.datetime(2009, 1, 1)
         data_date = date
@@ -107,7 +107,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     index = pds.date_range(pysat.datetime(2008, 1, 1),
                            pysat.datetime(2010, 12, 31))
-    names = [data_path+date.strftime('%D')+'.nofile' for date in index]
+    names = [data_path + date.strftime('%Y-%m-%d') + '.nofile'
+             for date in index]
     return pysat.Series(names, index=index)
 
 

--- a/pysat/instruments/pysat_testadd1.py
+++ b/pysat/instruments/pysat_testadd1.py
@@ -5,6 +5,7 @@ Adapted from existing pysat testing instrument, but changes the data in
 dummy1 to ascending integers and deletes dummy2-4
 """
 
+import os
 import numpy as np
 import pandas as pds
 

--- a/pysat/instruments/pysat_testadd1.py
+++ b/pysat/instruments/pysat_testadd1.py
@@ -5,8 +5,9 @@ Adapted from existing pysat testing instrument, but changes the data in
 dummy1 to ascending integers and deletes dummy2-4
 """
 
-import pandas as pds
 import numpy as np
+import pandas as pds
+
 import pysat
 
 # pysat required parameters

--- a/pysat/instruments/pysat_testadd1.py
+++ b/pysat/instruments/pysat_testadd1.py
@@ -62,10 +62,10 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     """
 
     # create an artifical satellite data set
-    parts = fnames[0].split('-')
-    yr = int('20' + parts[-1][0:2])
-    month = int(parts[-3])
-    day = int(parts[-2])
+    parts = os.path.split(fnames[0])[-1].split('-')
+    yr = int(parts[0])
+    month = int(parts[1])
+    day = int(parts[2][0:2])
 
     date = pysat.datetime(yr, month, day)
     if sim_multi_file_right:

--- a/pysat/instruments/pysat_testadd2.py
+++ b/pysat/instruments/pysat_testadd2.py
@@ -31,7 +31,7 @@ def init(self):
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
     # create an artifical satellite data set
-    parts = fnames[0].split('/')
+    parts = fnames[0].split('-')
     yr = int('20' + parts[-1][0:2])
     month = int(parts[-3])
     day = int(parts[-2])
@@ -107,7 +107,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     index = pds.date_range(pysat.datetime(2008, 1, 1),
                            pysat.datetime(2010, 12, 31))
-    names = [data_path + date.strftime('%D') + '.nofile' for date in index]
+    names = [data_path + date.strftime('%Y-%m-%d') + '.nofile'
+             for date in index]
     return pysat.Series(names, index=index)
 
 

--- a/pysat/instruments/pysat_testadd2.py
+++ b/pysat/instruments/pysat_testadd2.py
@@ -5,6 +5,7 @@ Adapted from existing pysat testing instrument, but changes the data in
 dummy1 to negative integers descending from 0 and deletes dummy2-4
 """
 
+import os
 import numpy as np
 import pandas as pds
 

--- a/pysat/instruments/pysat_testadd2.py
+++ b/pysat/instruments/pysat_testadd2.py
@@ -31,6 +31,36 @@ def init(self):
 
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
+    """ Loads the test files
+
+    Parameters
+    ----------
+    fnames : (list)
+        List of filenames
+    tag : (str or NoneType)
+        Instrument tag (accepts '' or a number (i.e., '10'), which specifies
+        the number of times to include in the test instrument)
+    sat_id : (str or NoneType)
+        Instrument satellite ID (accepts '')
+    sim_multi_file_right : (boolean)
+        Adjusts date range to be 12 hours in the future or twelve hours beyond
+        root_date (default=False)
+    sim_multi_file_left : (boolean)
+        Adjusts date range to be 12 hours in the past or twelve hours before
+        root_date (default=False)
+    root_date : (NoneType)
+        Optional central date, uses test_dates if not specified.
+        (default=None)
+
+    Returns
+    -------
+    data : (pds.DataFrame)
+        Testing data
+    meta : (pysat.Meta)
+        Metadataxs
+
+    """
+
     # create an artifical satellite data set
     parts = fnames[0].split('-')
     yr = int('20' + parts[-1][0:2])

--- a/pysat/instruments/pysat_testadd2.py
+++ b/pysat/instruments/pysat_testadd2.py
@@ -5,8 +5,9 @@ Adapted from existing pysat testing instrument, but changes the data in
 dummy1 to negative integers descending from 0 and deletes dummy2-4
 """
 
-import pandas as pds
 import numpy as np
+import pandas as pds
+
 import pysat
 
 # pysat required parameters

--- a/pysat/instruments/pysat_testadd2.py
+++ b/pysat/instruments/pysat_testadd2.py
@@ -62,10 +62,10 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     """
 
     # create an artifical satellite data set
-    parts = fnames[0].split('-')
-    yr = int('20' + parts[-1][0:2])
-    month = int(parts[-3])
-    day = int(parts[-2])
+    parts = os.path.split(fnames[0])[-1].split('-')
+    yr = int(parts[0])
+    month = int(parts[1])
+    day = int(parts[2][0:2])
 
     date = pysat.datetime(yr, month, day)
     if sim_multi_file_right:

--- a/pysat/instruments/pysat_testadd3.py
+++ b/pysat/instruments/pysat_testadd3.py
@@ -31,6 +31,36 @@ def init(self):
 
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
+    """ Loads the test files
+
+    Parameters
+    ----------
+    fnames : (list)
+        List of filenames
+    tag : (str or NoneType)
+        Instrument tag (accepts '' or a number (i.e., '10'), which specifies
+        the number of times to include in the test instrument)
+    sat_id : (str or NoneType)
+        Instrument satellite ID (accepts '')
+    sim_multi_file_right : (boolean)
+        Adjusts date range to be 12 hours in the future or twelve hours beyond
+        root_date (default=False)
+    sim_multi_file_left : (boolean)
+        Adjusts date range to be 12 hours in the past or twelve hours before
+        root_date (default=False)
+    root_date : (NoneType)
+        Optional central date, uses test_dates if not specified.
+        (default=None)
+
+    Returns
+    -------
+    data : (pds.DataFrame)
+        Testing data
+    meta : (pysat.Meta)
+        Metadataxs
+
+    """
+
     # create an artifical satellite data set
     parts = fnames[0].split('-')
     yr = int('20' + parts[-1][0:2])

--- a/pysat/instruments/pysat_testadd3.py
+++ b/pysat/instruments/pysat_testadd3.py
@@ -31,7 +31,7 @@ def init(self):
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
     # create an artifical satellite data set
-    parts = fnames[0].split('/')
+    parts = fnames[0].split('-')
     yr = int('20' + parts[-1][0:2])
     month = int(parts[-3])
     day = int(parts[-2])
@@ -106,7 +106,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     index = pds.date_range(pysat.datetime(2008, 1, 1),
                            pysat.datetime(2010, 12, 31))
-    names = [data_path + date.strftime('%D') + '.nofile' for date in index]
+    names = [data_path + date.strftime('%Y-%m-%d') + '.nofile'
+             for date in index]
     return pysat.Series(names, index=index)
 
 

--- a/pysat/instruments/pysat_testadd3.py
+++ b/pysat/instruments/pysat_testadd3.py
@@ -5,8 +5,9 @@ Adapted from existing pysat testing instrument, but changes the data in
 dummy1 to ascending integers from 10 and deletes dummy2-4
 """
 
-import pandas as pds
 import numpy as np
+import pandas as pds
+
 import pysat
 
 # pysat required parameters

--- a/pysat/instruments/pysat_testadd3.py
+++ b/pysat/instruments/pysat_testadd3.py
@@ -62,10 +62,10 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     """
 
     # create an artifical satellite data set
-    parts = fnames[0].split('-')
-    yr = int('20' + parts[-1][0:2])
-    month = int(parts[-3])
-    day = int(parts[-2])
+    parts = os.path.split(fnames[0])[-1].split('-')
+    yr = int(parts[0])
+    month = int(parts[1])
+    day = int(parts[2][0:2])
 
     date = pysat.datetime(yr, month, day)
     if sim_multi_file_right:

--- a/pysat/instruments/pysat_testadd3.py
+++ b/pysat/instruments/pysat_testadd3.py
@@ -5,6 +5,7 @@ Adapted from existing pysat testing instrument, but changes the data in
 dummy1 to ascending integers from 10 and deletes dummy2-4
 """
 
+import os
 import numpy as np
 import pandas as pds
 

--- a/pysat/instruments/pysat_testadd4.py
+++ b/pysat/instruments/pysat_testadd4.py
@@ -31,6 +31,36 @@ def init(self):
 
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
+    """ Loads the test files
+
+    Parameters
+    ----------
+    fnames : (list)
+        List of filenames
+    tag : (str or NoneType)
+        Instrument tag (accepts '' or a number (i.e., '10'), which specifies
+        the number of times to include in the test instrument)
+    sat_id : (str or NoneType)
+        Instrument satellite ID (accepts '')
+    sim_multi_file_right : (boolean)
+        Adjusts date range to be 12 hours in the future or twelve hours beyond
+        root_date (default=False)
+    sim_multi_file_left : (boolean)
+        Adjusts date range to be 12 hours in the past or twelve hours before
+        root_date (default=False)
+    root_date : (NoneType)
+        Optional central date, uses test_dates if not specified.
+        (default=None)
+
+    Returns
+    -------
+    data : (pds.DataFrame)
+        Testing data
+    meta : (pysat.Meta)
+        Metadataxs
+
+    """
+
     # create an artifical satellite data set
     parts = fnames[0].split('-')
     yr = int('20' + parts[-1][0:2])

--- a/pysat/instruments/pysat_testadd4.py
+++ b/pysat/instruments/pysat_testadd4.py
@@ -5,6 +5,7 @@ Adapted from existing pysat testing instrument, but changes the data in
 dummy1 to ascending integers and deletes dummy2-4
 """
 
+import os
 import numpy as np
 import pandas as pds
 

--- a/pysat/instruments/pysat_testadd4.py
+++ b/pysat/instruments/pysat_testadd4.py
@@ -31,7 +31,7 @@ def init(self):
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
     # create an artifical satellite data set
-    parts = fnames[0].split('/')
+    parts = fnames[0].split('-')
     yr = int('20' + parts[-1][0:2])
     month = int(parts[-3])
     day = int(parts[-2])
@@ -107,7 +107,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     index = pds.date_range(pysat.datetime(2008, 1, 1),
                            pysat.datetime(2010, 12, 31))
-    names = [data_path+date.strftime('%D') + '.nofile' for date in index]
+    names = [data_path + date.strftime('%Y-%m-%d') + '.nofile'
+             for date in index]
     return pysat.Series(names, index=index)
 
 

--- a/pysat/instruments/pysat_testadd4.py
+++ b/pysat/instruments/pysat_testadd4.py
@@ -5,8 +5,9 @@ Adapted from existing pysat testing instrument, but changes the data in
 dummy1 to ascending integers and deletes dummy2-4
 """
 
-import pandas as pds
 import numpy as np
+import pandas as pds
+
 import pysat
 
 # pysat required parameters

--- a/pysat/instruments/pysat_testadd4.py
+++ b/pysat/instruments/pysat_testadd4.py
@@ -62,10 +62,10 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     """
 
     # create an artifical satellite data set
-    parts = fnames[0].split('-')
-    yr = int('20' + parts[-1][0:2])
-    month = int(parts[-3])
-    day = int(parts[-2])
+    parts = os.path.split(fnames[0])[-1].split('-')
+    yr = int(parts[0])
+    month = int(parts[1])
+    day = int(parts[2][0:2])
 
     date = pysat.datetime(yr, month, day)
     if sim_multi_file_right:

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -7,8 +7,8 @@ from __future__ import absolute_import
 import functools
 import os
 
-import pandas as pds
 import numpy as np
+import pandas as pds
 
 import pysat
 

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -99,8 +99,8 @@ def init(self):
     if 'file_date_range' in self.kwargs:
         # set list files routine to desired date range
         # attach to the instrument object
-        self._list_rtn = functools.partial(list_files, \
-                                file_date_range=self.kwargs['file_date_range'])
+        fdr = self.kwargs['file_date_range']
+        self._list_rtn = functools.partial(list_files, file_date_range=fdr)
         self.files.refresh()
 
 
@@ -139,6 +139,7 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
         Metadataxs
 
     """
+
     # create an artifical satellite data set
     parts = os.path.split(fnames[0])[-1].split('-')
     yr = int(parts[0])

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -42,6 +42,27 @@ def init(self):
 
 
 def load(fnames, tag=None, sat_id=None):
+    """ Loads the test files
+
+    Parameters
+    ----------
+    fnames : (list)
+        List of filenames
+    tag : (str or NoneType)
+        Instrument tag (accepts '' or a number (i.e., '10'), which specifies
+        the number of times to include in the test instrument)
+    sat_id : (str or NoneType)
+        Instrument satellite ID (accepts '')
+
+    Returns
+    -------
+    data : (pds.DataFrame)
+        Testing data
+    meta : (pysat.Meta)
+        Metadataxs
+
+    """
+
     # create an artifical satellite data set
     parts = os.path.split(fnames[0])[-1].split('-')
     yr = int(parts[0])

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -4,11 +4,11 @@ Produces fake instrument data for testing.
 """
 from __future__ import print_function
 from __future__ import absolute_import
-
 import os
 
-import pandas as pds
 import numpy as np
+import pandas as pds
+
 import pysat
 
 platform = 'pysat'

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -37,7 +37,7 @@ def load(fnames, tag=None, sat_id=None):
 
     Returns
     -------
-    data : (pds.DataFrame)
+    data : (xr.Dataset)
         Testing data
     meta : (pysat.Meta)
         Metadataxs

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -23,6 +23,26 @@ def init(self):
 
 
 def load(fnames, tag=None, sat_id=None):
+    """ Loads the test files
+
+    Parameters
+    ----------
+    fnames : (list)
+        List of filenames
+    tag : (str or NoneType)
+        Instrument tag (accepts '' or a number (i.e., '10'), which specifies
+        the number of times to include in the test instrument)
+    sat_id : (str or NoneType)
+        Instrument satellite ID (accepts '')
+
+    Returns
+    -------
+    data : (pds.DataFrame)
+        Testing data
+    meta : (pysat.Meta)
+        Metadataxs
+
+    """
 
     # create an artifical satellite data set
     parts = os.path.split(fnames[0])[-1].split('-')

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -4,12 +4,12 @@ Produces fake instrument data for testing.
 """
 from __future__ import print_function
 from __future__ import absolute_import
-
 import os
 
+import numpy as np
 import pandas as pds
 import xarray as xr
-import numpy as np
+
 import pysat
 
 platform = 'pysat'

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -4,13 +4,13 @@ Produces fake instrument data for testing.
 """
 from __future__ import print_function
 from __future__ import absolute_import
-
 import os
 
-import pandas as pds
 import numpy as np
-import pysat
+import pandas as pds
 import xarray
+
+import pysat
 
 # pysat required parameters
 platform = 'pysat'

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -49,7 +49,7 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
 
     Returns
     -------
-    data : (pds.DataFrame)
+    data : (xr.Dataset)
         Testing data
     meta : (pysat.Meta)
         Metadataxs

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -29,6 +29,32 @@ def init(self):
 
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False):
+    """ Loads the test files
+
+    Parameters
+    ----------
+    fnames : (list)
+        List of filenames
+    tag : (str or NoneType)
+        Instrument tag (accepts '' or a number (i.e., '10'), which specifies
+        the number of times to include in the test instrument)
+    sat_id : (str or NoneType)
+        Instrument satellite ID (accepts '')
+    sim_multi_file_right : (boolean)
+        Adjusts date range to be 12 hours in the future or twelve hours beyond
+        root_date (default=False)
+    sim_multi_file_left : (boolean)
+        Adjusts date range to be 12 hours in the past or twelve hours before
+        root_date (default=False)
+
+    Returns
+    -------
+    data : (pds.DataFrame)
+        Testing data
+    meta : (pysat.Meta)
+        Metadataxs
+
+    """
 
     # create an artifical satellite data set
     parts = os.path.split(fnames[0])[-1].split('-')

--- a/pysat/instruments/pysat_testsmall.py
+++ b/pysat/instruments/pysat_testsmall.py
@@ -3,6 +3,7 @@
 Produces fake instrument data for testing.
 """
 
+import os
 import numpy as np
 import pandas as pds
 

--- a/pysat/instruments/pysat_testsmall.py
+++ b/pysat/instruments/pysat_testsmall.py
@@ -29,6 +29,36 @@ def init(self):
 
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
+    """ Loads the test files
+
+    Parameters
+    ----------
+    fnames : (list)
+        List of filenames
+    tag : (str or NoneType)
+        Instrument tag (accepts '' or a number (i.e., '10'), which specifies
+        the number of times to include in the test instrument)
+    sat_id : (str or NoneType)
+        Instrument satellite ID (accepts '')
+    sim_multi_file_right : (boolean)
+        Adjusts date range to be 12 hours in the future or twelve hours beyond
+        root_date (default=False)
+    sim_multi_file_left : (boolean)
+        Adjusts date range to be 12 hours in the past or twelve hours before
+        root_date (default=False)
+    root_date : (NoneType)
+        Optional central date, uses test_dates if not specified.
+        (default=None)
+
+    Returns
+    -------
+    data : (pds.DataFrame)
+        Testing data
+    meta : (pysat.Meta)
+        Metadataxs
+
+    """
+
     # create an artifical satellite data set
     parts = fnames[0].split('-')
     yr = int('20' + parts[-1][0:2])

--- a/pysat/instruments/pysat_testsmall.py
+++ b/pysat/instruments/pysat_testsmall.py
@@ -60,10 +60,10 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     """
 
     # create an artifical satellite data set
-    parts = fnames[0].split('-')
-    yr = int('20' + parts[-1][0:2])
-    month = int(parts[-3])
-    day = int(parts[-2])
+    parts = os.path.split(fnames[0])[-1].split('-')
+    yr = int(parts[0])
+    month = int(parts[1])
+    day = int(parts[2][0:2])
 
     date = pysat.datetime(yr, month, day)
     if sim_multi_file_right:

--- a/pysat/instruments/pysat_testsmall.py
+++ b/pysat/instruments/pysat_testsmall.py
@@ -3,8 +3,9 @@
 Produces fake instrument data for testing.
 """
 
-import pandas as pds
 import numpy as np
+import pandas as pds
+
 import pysat
 
 # pysat required parameters

--- a/pysat/instruments/pysat_testsmall.py
+++ b/pysat/instruments/pysat_testsmall.py
@@ -29,7 +29,7 @@ def init(self):
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
     # create an artifical satellite data set
-    parts = fnames[0].split('/')
+    parts = fnames[0].split('-')
     yr = int('20' + parts[-1][0:2])
     month = int(parts[-3])
     day = int(parts[-2])
@@ -106,7 +106,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     index = pds.date_range(pysat.datetime(2008, 1, 1),
                            pysat.datetime(2010, 12, 31))
-    names = [data_path + date.strftime('%D') + '.nofile' for date in index]
+    names = [data_path + date.strftime('%Y-%m-%d') + '.nofile'
+             for date in index]
     return pysat.Series(names, index=index)
 
 

--- a/pysat/instruments/pysat_testsmall2.py
+++ b/pysat/instruments/pysat_testsmall2.py
@@ -30,7 +30,7 @@ def init(self):
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
     # create an artifical satellite data set
-    parts = fnames[0].split('/')
+    parts = fnames[0].split('-')
     yr = int('20' + parts[-1][0:2])
     month = int(parts[-3])
     day = int(parts[-2])
@@ -107,7 +107,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     index = pds.date_range(pysat.datetime(2008, 1, 1),
                            pysat.datetime(2010, 12, 31))
-    names = [data_path + date.strftime('%D') + '.nofile' for date in index]
+    names = [data_path + date.strftime('%Y-%m-%d') + '.nofile'
+             for date in index]
     return pysat.Series(names, index=index)
 
 

--- a/pysat/instruments/pysat_testsmall2.py
+++ b/pysat/instruments/pysat_testsmall2.py
@@ -4,6 +4,7 @@ Produces fake instrument data for testing.
 Adapted from existing pysat testing instrument, but has fewer (100) rows
 """
 
+import os
 import numpy as np
 import pandas as pds
 

--- a/pysat/instruments/pysat_testsmall2.py
+++ b/pysat/instruments/pysat_testsmall2.py
@@ -30,6 +30,36 @@ def init(self):
 
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None):
+    """ Loads the test files
+
+    Parameters
+    ----------
+    fnames : (list)
+        List of filenames
+    tag : (str or NoneType)
+        Instrument tag (accepts '' or a number (i.e., '10'), which specifies
+        the number of times to include in the test instrument)
+    sat_id : (str or NoneType)
+        Instrument satellite ID (accepts '')
+    sim_multi_file_right : (boolean)
+        Adjusts date range to be 12 hours in the future or twelve hours beyond
+        root_date (default=False)
+    sim_multi_file_left : (boolean)
+        Adjusts date range to be 12 hours in the past or twelve hours before
+        root_date (default=False)
+    root_date : (NoneType)
+        Optional central date, uses test_dates if not specified.
+        (default=None)
+
+    Returns
+    -------
+    data : (pds.DataFrame)
+        Testing data
+    meta : (pysat.Meta)
+        Metadataxs
+
+    """
+
     # create an artifical satellite data set
     parts = fnames[0].split('-')
     yr = int('20' + parts[-1][0:2])

--- a/pysat/instruments/pysat_testsmall2.py
+++ b/pysat/instruments/pysat_testsmall2.py
@@ -61,10 +61,10 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     """
 
     # create an artifical satellite data set
-    parts = fnames[0].split('-')
-    yr = int('20' + parts[-1][0:2])
-    month = int(parts[-3])
-    day = int(parts[-2])
+    parts = os.path.split(fnames[0])[-1].split('-')
+    yr = int(parts[0])
+    month = int(parts[1])
+    day = int(parts[2][0:2])
 
     date = pysat.datetime(yr, month, day)
     if sim_multi_file_right:

--- a/pysat/instruments/pysat_testsmall2.py
+++ b/pysat/instruments/pysat_testsmall2.py
@@ -4,8 +4,9 @@ Produces fake instrument data for testing.
 Adapted from existing pysat testing instrument, but has fewer (100) rows
 """
 
-import pandas as pds
 import numpy as np
+import pandas as pds
+
 import pysat
 
 # pysat required parameters


### PR DESCRIPTION
Closes #86.

Summary of changes
- Updated pysat test instruments filenames to consistently use '%Y-%m-%d' format rather than '/' 
- Added docstring for load routines for all test instruments
- pep8 scrub 