### PR TITLE
Check for bad datetime when loading data

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -378,17 +378,17 @@ class Instrument(object):
                     try:
                         # Assume key[0] is integer (including list or slice)
                         return self.data.loc[self.data.index[key[0]], key[1]]
-                    except KeyError:
-                        try:
-                            # Try to force as integer (eg, if ndarray)
-                            idx = self.data.index[key[0].astype(int)]
-                            return self.data.loc[idx, key[1]]
-                        except ValueError:
-                            estring = '\n'.join(("Unable to sort out data.",
-                                                 "Instrument has data : " +
-                                                 str(not self.empty),
-                                                 "Requested key : ", str(key)))
-                            raise ValueError(estring)
+                    # except KeyError:
+                    #     try:
+                    #         # Try to force as integer (eg, if ndarray)
+                    #         idx = self.data.index[key[0].astype(int)]
+                    #         return self.data.loc[idx, key[1]]
+                    except ValueError:
+                        estring = '\n'.join(("Unable to sort out data.",
+                                             "Instrument has data : " +
+                                             str(not self.empty),
+                                             "Requested key : ", str(key)))
+                        raise ValueError(estring)
             else:
                 try:
                     # integer based indexing
@@ -496,10 +496,16 @@ class Instrument(object):
                     try:
                         # Assume key[0] is integer (including list or slice)
                         self.data.loc[self.data.index[key[0]], key[1]] = new
-                    except KeyError:
-                        # Try to force conversion to integer
-                        idx = self.data.index[key[0].astype(int)]
-                        self.data.loc[idx, key[1]] = new
+                    # except KeyError:
+                    #     # Try to force conversion to integer
+                    #     idx = self.data.index[key[0].astype(int)]
+                    #     self.data.loc[idx, key[1]] = new
+                    except ValueError:
+                        estring = '\n'.join(("Unable to sort out data access.",
+                                             "Instrument has data : " +
+                                             str(not self.empty),
+                                             "Requested key : ", str(key)))
+                        raise ValueError(estring)
                 self.meta[key[1]] = {}
                 return
             elif not isinstance(new, dict):

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -378,11 +378,6 @@ class Instrument(object):
                     try:
                         # Assume key[0] is integer (including list or slice)
                         return self.data.loc[self.data.index[key[0]], key[1]]
-                    # except KeyError:
-                    #     try:
-                    #         # Try to force as integer (eg, if ndarray)
-                    #         idx = self.data.index[key[0].astype(int)]
-                    #         return self.data.loc[idx, key[1]]
                     except ValueError:
                         estring = '\n'.join(("Unable to sort out data.",
                                              "Instrument has data : " +
@@ -496,10 +491,6 @@ class Instrument(object):
                     try:
                         # Assume key[0] is integer (including list or slice)
                         self.data.loc[self.data.index[key[0]], key[1]] = new
-                    # except KeyError:
-                    #     # Try to force conversion to integer
-                    #     idx = self.data.index[key[0].astype(int)]
-                    #     self.data.loc[idx, key[1]] = new
                     except ValueError:
                         estring = '\n'.join(("Unable to sort out data access.",
                                              "Instrument has data : " +

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -947,9 +947,9 @@ class Instrument(object):
                 # ensure units and name are named consistently in new Meta
                 # object as specified by user upon Instrument instantiation
                 mdata.accept_default_labels(self)
-                bad_data = False
+                bad_datetime = False
             except pds.errors.OutOfBoundsDatetime:
-                bad_data = True
+                bad_datetime = True
                 data = self._null_data.copy()
                 mdata = _meta.Meta(units_label=self.units_label,
                                    name_label=self.name_label,
@@ -963,6 +963,7 @@ class Instrument(object):
                                    fill_label=self.fill_label)
 
         else:
+            bad_datetime = False
             data = self._null_data.copy()
             mdata = _meta.Meta(units_label=self.units_label,
                                name_label=self.name_label,
@@ -1002,7 +1003,7 @@ class Instrument(object):
                                            fname[-1]))
         else:
             # no data signal
-            if bad_data:
+            if bad_datetime:
                 output_str = ' '.join(('Bad datetime for', output_str,
                                        date.strftime('%d %B %Y')))
             else:


### PR DESCRIPTION
Uploading for comments.  Addresses #87.

If `pandas.errors.OutOfBoundsDatetime` occurs during file load, does not return data.  Functionally acts as if file is missing (ie, continues with a data gap, but returns a 'Bad datetime for...' rather than a 'No data for...' message to the screen to alert user of a problem.

Ideally, this should scan for the `xarray` equivalent as well.