### PR TITLE
xarray len deprecation fix

### DIFF
--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -126,7 +126,8 @@ class Custom(object):
         if len(self._functions) > 0:
             for func, arg, kwarg, kind in zip(self._functions, self._args,
                                               self._kwargs, self._kind):
-                if len(sat.data) > 0:
+                ind = sat.data.index if sat.pandas_format else sat.data.indexes
+                if len(ind) > 0:
                     if kind == 'add':
                         # apply custom functions that add data to the
                         # instrument object

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -126,8 +126,7 @@ class Custom(object):
         if len(self._functions) > 0:
             for func, arg, kwarg, kind in zip(self._functions, self._args,
                                               self._kwargs, self._kind):
-                ind = sat.data.index if sat.pandas_format else sat.data.indexes
-                if len(ind) > 0:
+                if not sat.empty:
                     if kind == 'add':
                         # apply custom functions that add data to the
                         # instrument object

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -622,7 +622,10 @@ class Instrument(object):
         if self.pandas_format:
             return self.data.empty
         else:
-            return len(self.data.variables) == 0
+            if 'time' in self.data.indexes:
+                return len(self.data.indexes['time']) == 0
+            else:
+                return True
 
     def _empty(self, data=None):
         """Boolean flag reflecting lack of data.

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -985,7 +985,8 @@ class Instrument(object):
             raise TypeError('Metadata returned must be a pysat.Meta object')
 
         # let user know if data was returned or not
-        if len(data) > 0:
+        ind = data.index if self.pandas_format else data.indexes
+        if len(ind) > 0:
             if date is not None:
                 output_str = ' '.join(('Returning', output_str, 'data for',
                                        date.strftime('%d %B %Y')))

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -922,7 +922,7 @@ class Instrument(object):
 
         Returns
         --------
-        data : (pds.DataFrame)
+        data : (pds.DataFrame or xr.Dataset)
             pysat data
         meta : (pysat.Meta)
             pysat meta data


### PR DESCRIPTION
Addresses #130.

Starting with xarray 0.11.0, `len` cannot directly be run on a Dataset.  Updates syntax accordingly.