### PR TITLE
version limits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,18 @@ with open(os.path.join(here, version_filename)) as version_file:
 
 # change setup.py for readthedocs
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
-install_requires = ['xarray', 'pandas>=0.19.2', 'numpy>=1.12',  'sgp4',
-                    'pyEphem', 'requests', 'beautifulsoup4', 'lxml',
-                    'pysatCDF', 'apexpy', 'aacgmv2', 'pysatMagVect',
-                    'madrigalWeb', 'h5py', 'PyForecastTools', 'pyglow']
+if sys.version_info.major == 2:
+    install_requires = ['xarray<0.12', 'pandas>=0.19.2, <0.25', 'numpy>=1.12',
+                        'sgp4', 'pyEphem', 'requests', 'beautifulsoup4',
+                        'lxml', 'pysatCDF', 'apexpy', 'aacgmv2',
+                        'pysatMagVect', 'madrigalWeb', 'h5py',
+                        'PyForecastTools', 'pyglow']
+else:
+    install_requires = ['xarray', 'pandas>=0.19.2', 'numpy>=1.12',
+                        'sgp4', 'pyEphem', 'requests', 'beautifulsoup4',
+                        'lxml', 'pysatCDF', 'apexpy', 'aacgmv2',
+                        'pysatMagVect', 'madrigalWeb', 'h5py',
+                        'PyForecastTools', 'pyglow']
 
 # all packages after pysatCDF are excluded if on ReadTheDocs
 if on_rtd:


### PR DESCRIPTION
Addresses #187. 

Adds version limits to pandas and xarray for python 2.7. Python 3 and up has no limit largely so Travis CI can keep testing the latest version and update us on when new versions break.  