### PR TITLE
prelim download bugfix

### DIFF
--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -197,6 +197,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     Called by pysat. Not intended for direct use by user.
 
     """
+    import time
 
     if data_path is not None:
         if tag == '':
@@ -243,7 +244,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
             # year of data and use the appended date to select out appropriate
             # data.
             if format_str is None:
-                format_str = 'f107_prelim_{year:04d}_v{version:01d}.txt'
+                format_str = \
+                    'f107_prelim_{year:04d}_{month:02d}_v{version:01d}.txt'
             out = pysat.Files.from_os(data_path=data_path,
                                       format_str=format_str)
 
@@ -255,12 +257,20 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
                 for orig in orig_files.iteritems():
                     # Version determines each file's valid length
                     version = int(orig[1].split("_v")[1][0])
-                    doff = pds.DateOffset(years=1) if version == 5 \
+                    doff = pds.DateOffset(years=1) if version == 2 \
                         else pds.DateOffset(months=3)
                     istart = orig[0]
-                    if version < 5 and version > 1:
-                        istart += pds.DateOffset(months=(version-1) * 3)
+                    #if version < 5 and version > 1:
+                    #    istart += pds.DateOffset(months=(version-1) * 3)
                     iend = istart + doff - pds.DateOffset(days=1)
+
+                    # Ensure the end time does not extend past the number of
+                    # possible days included based on the file's download time
+                    fname = os.path.join(data_path, orig[1])
+                    dend = pds.datetime.fromtimestamp(os.path.getctime(fname))
+                    dend = dend - pds.DateOffset(days=1)
+                    if dend < iend:
+                        iend = dend
 
                     # Pad the original file index
                     out.loc[iend] = orig[1]
@@ -424,19 +434,24 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
 
         bad_fname = list()
 
-        # Get the local files, to ensure that the most recent file is
-        # downloaded again since it will have more data
+        # Get the local files, to ensure that the version 1 files are downloaded
+        # again if more data has been added
         local_files = list_files(tag, sat_id, data_path)
-        got_today = False
 
-        for date in date_array:
+        # To avoid downloading multiple files, cycle dates based on file length
+        date = date_array[0]
+        while date <= date_array[-1]:
             # The file name changes, depending on how recent the requested
             # data is
-            qnum = (date.month-1) / 3 + 1
+            qnum = (date.month-1) // 3 + 1 # Integer floor division
+            qmonth = (qnum-1) * 3 + 1
             quar = 'Q{:d}_'.format(qnum)
             fnames = ['{:04d}{:s}DSD.txt'.format(date.year, ss)
                       for ss in ['_', quar]]
-            versions = ["5", "{:d}".format(qnum)]
+            versions = ["01_v2", "{:02d}_v1".format(qmonth)]
+            vend = [pysat.datetime(date.year, 12, 31),
+                    pysat.datetime(date.year, qmonth, 1)
+                    + pds.DateOffset(months=3) - pds.DateOffset(days=1)]
             downloaded = False
             rewritten = False
 
@@ -448,9 +463,9 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
 
                 local_fname = fname
                 saved_fname = os.path.join(data_path, local_fname)
-                outfile = os.path.join(data_path, 'f107_prelim_'
-                                       + "{:04d}_v".format(date.year)
-                                       + versions[iname] + ".txt")
+                ofile = '_'.join(['f107', 'prelim', '{:04d}'.format(date.year),
+                                  '{:s}.txt'.format(versions[iname])])
+                outfile = os.path.join(data_path, ofile)
 
                 if os.path.isfile(outfile):
                     downloaded = True
@@ -459,32 +474,37 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
                     checkfile = os.path.split(outfile)[-1]
                     has_file = local_files == checkfile
                     if np.any(has_file):
-                        if has_file[has_file].index[-1] < today or got_today:
-                            rewritten = True
-                            break
+                        if has_file[has_file].index[-1] < vend[iname]:
+                            # This file will be updated again, but only attempt
+                            # to do so if enough time has passed from the
+                            # last time it was downloaded
+                            yesterday = today - pds.DateOffset(days=1)
+                            if has_file[has_file].index[-1] < yesterday:
+                                rewritten = True
+
+                # Attempt to download if the file does not exist or if the
+                # file has been updated
+                if rewritten or not downloaded:
+                    try:
+                        sys.stdout.flush()
+                        ftp.retrbinary('RETR ' + fname,
+                                       open(saved_fname, 'wb').write)
+                        downloaded = True
+                        print('Downloaded file for ' + date.strftime('%x'))
+
+                    except ftplib.error_perm as exception:
+                        # Could not fetch, so cannot rewrite
+                        rewritten = False
+
+                        # Test for an error
+                        if str(exception.args[0]).split(" ", 1)[0] != '550':
+                            raise RuntimeError(exception)
                         else:
-                            got_today = True
+                            # file isn't actually there, try the next name
+                            os.remove(saved_fname)
 
-                try:
-                    print('Downloading file for ' + date.strftime('%x'))
-                    sys.stdout.flush()
-                    ftp.retrbinary('RETR ' + fname,
-                                   open(saved_fname, 'wb').write)
-                    downloaded = True
-
-                except ftplib.error_perm as exception:
-                    # Signal that we don't have today's file
-                    got_today = False
-
-                    # Test for an error
-                    if str(exception.args[0]).split(" ", 1)[0] != '550':
-                        raise RuntimeError(exception)
-                    else:
-                        # file isn't actually there, try the next name
-                        os.remove(saved_fname)
-
-                        # Save this so we don't try again
-                        bad_fname.append(fname)
+                            # Save this so we don't try again
+                            bad_fname.append(fname)
 
                 # If the first file worked, don't try again
                 if downloaded:
@@ -492,12 +512,15 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
 
             if not downloaded:
                 print('File not available for {:}'.format(date.strftime('%x')))
-            elif not rewritten:
+            elif rewritten:
                 with open(saved_fname, 'r') as fprelim:
                     lines = fprelim.read()
 
                 rewrite_daily_file(date.year, outfile, lines)
                 os.remove(saved_fname)
+
+            # Cycle to the next date
+            date = vend[iname] + pds.DateOffset(days=1)
 
         # Close connection after downloading all dates
         ftp.close()

--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -260,14 +260,12 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
                     doff = pds.DateOffset(years=1) if version == 2 \
                         else pds.DateOffset(months=3)
                     istart = orig[0]
-                    #if version < 5 and version > 1:
-                    #    istart += pds.DateOffset(months=(version-1) * 3)
                     iend = istart + doff - pds.DateOffset(days=1)
 
                     # Ensure the end time does not extend past the number of
                     # possible days included based on the file's download time
                     fname = os.path.join(data_path, orig[1])
-                    dend = pds.datetime.fromtimestamp(os.path.getctime(fname))
+                    dend = pds.datetime.utcfromtimestamp(os.path.getctime(fname))
                     dend = dend - pds.DateOffset(days=1)
                     if dend < iend:
                         iend = dend
@@ -504,6 +502,9 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
                             os.remove(saved_fname)
 
                             # Save this so we don't try again
+                            # Because there are two possible filenames for
+                            # each time, it's ok if one isn't there.  We just
+                            # don't want to keep looking for it.
                             bad_fname.append(fname)
 
                 # If the first file worked, don't try again


### PR DESCRIPTION
Changed the way that preliminary F10.7 data files are listed and downloaded
- Changed listing to include only data up to the day before the file was downloaded, since it can't know the future
- Changed the versioning to have two versions for quarterly and yearly, since pysat will ignore earlier versions of files
- Changed date in filename to include the month, since version numbers are not the correct way to count quarters
- Changed the downloads to check for the expected end of the file, since the listing has improved.