### PR TITLE
update f107 url

### DIFF
--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -368,7 +368,7 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
                 raise ValueError('The Download routine must be invoked with ' +
                                  'a freq="MS" option.')
             # download webpage
-            dstr = 'http://lasp.colorado.edu/lisird/latis/'
+            dstr = 'http://lasp.colorado.edu/lisird/latis/dap/'
             dstr += 'noaa_radio_flux.json?time%3E='
             dstr += date.strftime('%Y-%m-%d')
             dstr += 'T00:00:00.000Z&time%3C='
@@ -400,7 +400,7 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
         import json
 
         # download webpage
-        dstr = 'http://lasp.colorado.edu/lisird/latis/'
+        dstr = 'http://lasp.colorado.edu/lisird/latis/dap/'
         dstr += 'noaa_radio_flux.json?time%3E='
         dstr += pysat.datetime(1947, 2, 13).strftime('%Y-%m-%d')
         dstr += 'T00:00:00.000Z&time%3C='


### PR DESCRIPTION
LISIRD has updated the web address for F10.7 data.  This addresses the problem found in #211 and #212.

Note that this is a patch.  LISIRD is migrating to using the "Penticton Solar Radio Flux at 10.7cm", which has a higher time resolution.