### PR TITLE
Version limits for numpy and scipy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ with open(os.path.join(here, version_filename)) as version_file:
 # change setup.py for readthedocs
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if sys.version_info.major == 2:
-    install_requires = ['xarray<0.12', 'pandas>=0.19.2, <0.25', 'numpy>=1.12',
-                        'scipy<1.3', 'sgp4', 'pyEphem', 'requests',
-                        'beautifulsoup4',
+    install_requires = ['xarray<0.12', 'pandas>=0.19.2, <0.25',
+                        'numpy>=1.12, <1.17', 'scipy<1.3', 'sgp4',
+                        'pyEphem', 'requests', 'beautifulsoup4',
                         'lxml', 'pysatCDF', 'apexpy', 'aacgmv2',
                         'pysatMagVect', 'madrigalWeb', 'h5py',
                         'PyForecastTools', 'pyglow']

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ with open(os.path.join(here, version_filename)) as version_file:
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if sys.version_info.major == 2:
     install_requires = ['xarray<0.12', 'pandas>=0.19.2, <0.25', 'numpy>=1.12',
-                        'sgp4', 'pyEphem', 'requests', 'beautifulsoup4',
+                        'scipy<1.3', 'sgp4', 'pyEphem', 'requests',
+                        'beautifulsoup4',
                         'lxml', 'pysatCDF', 'apexpy', 'aacgmv2',
                         'pysatMagVect', 'madrigalWeb', 'h5py',
                         'PyForecastTools', 'pyglow']


### PR DESCRIPTION
An upper limit for `scipy` must be added to maintain testing for python 2.7.   Travis CI will always try to install the latest version unless told otherwise.  The release of scipy 1.3 is not backwards-compatible with python 2.7.  See log of https://travis-ci.org/rstoneback/pysat/jobs/526104564 for example.

While `scipy` is not a pysat requirement, it is a requirement for `xarray`, leading to this problem.

An upper limit for `numpy` has been added as well to prevent this problem from reoccurring when numpy 1.17 is released later this year.

As with #201, upper limits are only imposed on python 2.7 to allow the latest versions to be tested in 3.7.