### PR TITLE
Travis CI updates - python 2.7.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 matrix:
   include:
-    - python: 2.7
+    - python: 2.7.14
     - python: 3.7
       dist: xenial
       services: xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 matrix:
   include:
-    - python: 2.7
-      dist: trusty
+    - python: 2.7.14
+      services: xvfb
     - python: 3.7
       dist: xenial
       services: xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 matrix:
   include:
-    - python: 2.7.14
+    - python: 2.7
+      dist: trusty
     - python: 3.7
       dist: xenial
       services: xvfb


### PR DESCRIPTION
Travis CI has updated to using xenial as the default for the 2.7 branch.  This causes apexpy to fail to install (see log in https://travis-ci.org/rstoneback/pysat/jobs/526501730), and tests are not run for pysat.  This is due to 2.7.15 being the default on xenial.

Recommend forcing travis to use 2.7.14 while this is sorted out.