### PR TITLE
bugfix - saber directory

### DIFF
--- a/pysat/instruments/timed_saber.py
+++ b/pysat/instruments/timed_saber.py
@@ -134,7 +134,7 @@ load = cdw.load
 # a dictionary needs to be created for each sat_id and tag
 # combination along with the file format template
 # outer dict keyed by sat_id, inner dict keyed by tag
-basic_tag = {'dir': '/pub/data/timed/saber/version2_0/level2a_cdf',
+basic_tag = {'dir': '/pub/data/timed/saber/level2a_v2_00_CDF',
              'remote_fname': '{year:4d}/{month:02d}/' + fname,
              'local_fname': fname}
 supported_tags = {'': {'': basic_tag}}


### PR DESCRIPTION
CDAWeb has updated the directory structure for TIMED/SABER to add new data products.  Rather than add everything now, I'm updating the default dataset so that unit tests can continue uninterrupted.