### PR TITLE
tidy up old print statements

### DIFF
--- a/demo/cosmic_and_ivm_demo.py
+++ b/demo/cosmic_and_ivm_demo.py
@@ -41,18 +41,18 @@ def geo2mag(incoord):
     Examples
     --------
     mag =  geo2mag(np.array([[80.08],[287.789]]))
-    print mag
-    print 'We should get [90,0]'
+    print(mag)
+    print('We should get [90,0]')
 
     mag =  geo2mag(np.array([[90],[0]]))
-    print mag
-    print 'We should get something close to [80.02, 180]'
+    print(mag)
+    print('We should get something close to [80.02, 180]')
 
 
     # kyoto, japan
     mag =  geo2mag(np.array([[35.],[135.45]]))
-    print mag
-    print 'We should get something close to [25.87, -154.94]'
+    print(mag)
+    print('We should get something close to [25.87, -154.94]')
 
     """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,9 +23,7 @@ import shlex
 #sys.path.insert(0, os.path.abspath('.'))
 
 sys.path.insert(0,os.path.abspath('..'))
-#print sys.path
 import pysat
-#print pysat.__path__
 
 
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1211,7 +1211,6 @@ class Instrument(object):
             # specific date if loading by day
             # set up times for the possible data padding coming up
             if self._load_by_date:
-                # print ('double trouble')
                 first_time = self.date
                 first_pad = self.date - loop_pad
                 last_time = self.date + pds.DateOffset(days=1)
@@ -1219,7 +1218,6 @@ class Instrument(object):
                 want_last_pad = False
             # loading by file, can't be a multi_file-day flag situation
             elif (not self._load_by_date) and (not self.multi_file_day):
-                # print ('single trouble')
                 first_time = self._index(self._curr_data)[0]
                 first_pad = first_time - loop_pad
                 last_time = self._index(self._curr_data)[-1]
@@ -1229,7 +1227,6 @@ class Instrument(object):
                 raise ValueError("multi_file_day and loading by date are " +
                                  "effectively equivalent.  Can't have " +
                                  "multi_file_day and load by file.")
-            # print (first_pad, first_time, last_time, last_pad)
 
             # pad data based upon passed parameter
             if (not self._empty(self._prev_data)) & (not self.empty):
@@ -1492,8 +1489,8 @@ class Instrument(object):
             # longer than a day then the download defaults would
             # no longer be correct. Dates are always correct in this
             # setup.
-            print ('Downloading the most recent data by default ',
-                   '(yesterday through tomorrow).')
+            print('Downloading the most recent data by default ',
+                  '(yesterday through tomorrow).')
             start = self.yesterday()
             stop = self.tomorrow()
         print('Downloading data to: ', self.files.data_path)
@@ -1895,7 +1892,7 @@ class Instrument(object):
         if (coltype == type(' ')) or (coltype == type(u' ')):
             # if isinstance(coltype, str):
             remove = True
-        # print ('coltype', coltype, remove, type(coltype), )
+        # print('coltype', coltype, remove, type(coltype), )
         if u'_FillValue' in mdata_dict.keys():
             # make sure _FillValue is the same type as the data
             if remove:
@@ -2118,7 +2115,6 @@ class Instrument(object):
             # iterate over all of the columns in the Instrument dataframe
             # check what kind of data we are dealing with, then store
             for key in self.variables:
-                # print (key)
                 # get information on type data we are dealing with
                 # data is data in proer type( multiformat support)
                 # coltype is the direct type, np.int64
@@ -2276,12 +2272,9 @@ class Instrument(object):
                                     new_dict['Format'] = \
                                         self._get_var_type_code(coltype)
                                     new_dict['Var_Type'] = 'data'
-                                    # print('Frame Writing ', key, col,
-                                    # export_meta[key].children[col])
                                     new_dict = \
                                         self._filter_netcdf4_metadata(new_dict,
                                                                       coltype)
-                                    # print ('mid2 ', new_dict)
                                     cdfkey.setncatts(new_dict)
                                 except KeyError as err:
                                     print(' '.join((str(err), '\n',
@@ -2293,7 +2286,6 @@ class Instrument(object):
                                 # method as well astype method below collect
                                 # data into a numpy array, then write the full
                                 # array in one go
-                                # print(coltype, dims)
                                 temp_cdf_data = \
                                     np.zeros((num, dims[0])).astype(coltype)
                                 for i in range(num):
@@ -2329,7 +2321,6 @@ class Instrument(object):
                                         self._filter_netcdf4_metadata(new_dict,
                                                                       coltype)
                                     # really attach metadata now
-                                    # print ('mid3 ', new_dict)
                                     cdfkey.setncatts(new_dict)
                                 except KeyError as err:
                                     print(' '.join((str(err), '\n',

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -341,7 +341,6 @@ class Orbits(object):
             ind = np.hstack((ind, ut_ind))
             ind = np.sort(ind)
             ind = np.unique(ind)
-            # print 'Time Gap'
 
         # create orbitbreak index, ensure first element is always 0
         if ind[0] != 0:
@@ -494,16 +493,11 @@ class Orbits(object):
                             self._getBasicOrbit(orbit=1)
                         # check that this orbit should end on the current day
                         delta = true_date - self.sat.index[0]
-                        # print 'checking if first orbit should land on
-                        #     requested day'
-                        # print self.sat.date, self.sat.index[0], delta,
-                        #     delta >= self.orbit_period
                         if delta >= self.orbit_period:
                             # the orbit loaded isn't close enough to date
                             # to be the first orbit of the day, move forward
                             self.next()
                     except StopIteration:
-                        # print 'going for basic orbit'
                         self._getBasicOrbit(orbit=1)
                         # includes hack to appear to be zero indexed
                         print('Loaded Orbit:%i' % (self._current - 1))
@@ -809,7 +803,7 @@ class Orbits(object):
         ::
 
             for inst in inst.orbits:
-                print 'next available orbit ', inst.data
+                print('next available orbit ', inst.data)
 
         Note
         ----

--- a/pysat/instruments/pysat_sgp4.py
+++ b/pysat/instruments/pysat_sgp4.py
@@ -149,7 +149,6 @@ def load(fnames, tag=None, sat_id=None, obs_long=0., obs_lat=0., obs_alt=0.,
         # orbit propagator - computes x,y,z position and velocity
         pos, vel = satellite.propagate(time.year, time.month, time.day,
                                        time.hour, time.minute, time.second)
-        # print (pos)
         position.extend(pos)
         velocity.extend(vel)
 
@@ -636,7 +635,6 @@ def add_iri_thermal_plasma(inst, glat_label='glat', glong_label='glong',
     from pyglow.pyglow import Point
 
     iri_params = []
-    # print 'IRI Simulations'
     for time, lat, lon, alt in zip(inst.data.index, inst[glat_label],
                                    inst[glong_label], inst[alt_label]):
         # Point class is instantiated. Its parameters are a function of time
@@ -654,7 +652,6 @@ def add_iri_thermal_plasma(inst, glat_label='glat', glong_label='glong',
         iri['frac_dens_h'] = pt.ni['H+']/iri['ion_dens']
         iri['frac_dens_he'] = pt.ni['HE+']/iri['ion_dens']
         iri_params.append(iri)
-    # print 'Complete.'
     iri = pds.DataFrame(iri_params)
     iri.index = inst.data.index
     inst[iri.keys()] = iri
@@ -724,7 +721,6 @@ def add_hwm_winds_and_ecef_vectors(inst, glat_label='glat',
         hwm['zonal_wind'] = pt.u
         hwm['meridional_wind'] = pt.v
         hwm_params.append(hwm)
-    # print 'Complete.'
     hwm = pds.DataFrame(hwm_params)
     hwm.index = inst.data.index
     inst[['zonal_wind', 'meridional_wind']] = hwm[['zonal_wind',
@@ -838,7 +834,6 @@ def add_igrf(inst, glat_label='glat', glong_label='glong', alt_label='alt'):
     import pysatMagVect
 
     igrf_params = []
-    # print 'IRI Simulations'
     for time, lat, lon, alt in zip(inst.data.index, inst[glat_label],
                                    inst[glong_label], inst[alt_label]):
         pt = Point(time, lat, lon, alt)
@@ -849,7 +844,6 @@ def add_igrf(inst, glat_label='glat', glong_label='glong', alt_label='alt'):
         igrf['B_north'] = pt.By
         igrf['B_up'] = pt.Bz
         igrf_params.append(igrf)
-    # print 'Complete.'
     igrf = pds.DataFrame(igrf_params)
     igrf.index = inst.data.index
     inst[igrf.keys()] = igrf
@@ -933,7 +927,6 @@ def add_msis(inst, glat_label='glat', glong_label='glong', alt_label='alt'):
     from pyglow.pyglow import Point
 
     msis_params = []
-    # print 'IRI Simulations'
     for time, lat, lon, alt in zip(inst.data.index, inst[glat_label],
                                    inst[glong_label], inst[alt_label]):
         pt = Point(time, lat, lon, alt)
@@ -949,7 +942,6 @@ def add_msis(inst, glat_label='glat', glong_label='glong', alt_label='alt'):
         msis['Nn_O2'] = pt.nn['O2']
         msis['Tn_msis'] = pt.Tn_msis
         msis_params.append(msis)
-    # print 'Complete.'
     msis = pds.DataFrame(msis_params)
     msis.index = inst.data.index
     inst[msis.keys()] = msis
@@ -1184,7 +1176,6 @@ def plot_simulated_data(ivm, filename=None):
         # aligned with ivm measurement sample
         lon0 = ivm[0, 'glong']
         lon1 = ivm[-1, 'glong']
-        # print (lon0, lon1)
 
         # enforce minimal longitude window, keep graphics from being too
         # disturbed
@@ -1195,8 +1186,7 @@ def plot_simulated_data(ivm, filename=None):
             lon0 -= 360.
             lon1 -= 360.
             ivm[:, 'glong'] -= 360.
-        # print (lon0, lon1)
-
+        
         m = Basemap(projection='mill', llcrnrlat=-60, urcrnrlat=60.,
                     urcrnrlon=lon1.copy(), llcrnrlon=lon0.copy(),
                     resolution='c', ax=ax6, fix_aspect=False)

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -100,7 +100,7 @@ def init(inst):
 
     Creates a file list for a given range if the file_date_range
     keyword is set at instantiation.
-    
+
     Parameters
     ----------
     file_date_range : (pds.date_range)
@@ -111,7 +111,7 @@ def init(inst):
 
     """
     inst.new_thing = True
-        
+
     # work on file index if keyword present
     if 'file_date_range' in inst.kwargs:
         # set list files routine to desired date range
@@ -119,7 +119,7 @@ def init(inst):
         fdr = inst.kwargs['file_date_range']
         inst._list_rtn = functools.partial(list_files, file_date_range=fdr)
         inst.files.refresh()
-        
+
     # mess with file dates if kwarg option present
     if 'mangle_file_dates' in inst.kwargs:
         if inst.kwargs['mangle_file_dates']:
@@ -127,7 +127,7 @@ def init(inst):
 
 def default(inst):
     """The default function is applied first to data as it is loaded.
-        
+
     """
     pass
 
@@ -255,10 +255,9 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     data['int16_dummy'] = np.ones(len(data), dtype=np.int16)
     data['int32_dummy'] = np.ones(len(data), dtype=np.int32)
     data['int64_dummy'] = np.ones(len(data), dtype=np.int64)
-    # print (data['string_dummy'])
     
-    index = pds.date_range(data_date, 
-                           data_date+pds.DateOffset(seconds=num-1), 
+    index = pds.date_range(data_date,
+                           data_date+pds.DateOffset(seconds=num-1),
                            freq='S')
     if malformed_index:
         index = index[0:num].tolist()
@@ -266,7 +265,7 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
         index[0:3], index[3:6] = index[3:6], index[0:3]
         # non unique
         index[6:9] = [index[6]]*3
-        
+
     data.index=index[0:num]
     data.index.name = 'Epoch'
     return data, meta.copy()

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -81,8 +81,8 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
         data_date = date
     num = 86400 if sat_id == '' else int(sat_id)
     num_array = np.arange(num)
-    index = pds.date_range(data_date, 
-                           data_date+pds.DateOffset(seconds=num-1), 
+    index = pds.date_range(data_date,
+                           data_date+pds.DateOffset(seconds=num-1),
                            freq='S')
     if malformed_index:
         index = index[0:num].tolist()
@@ -90,10 +90,10 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
         index[0:3], index[3:6] = index[3:6], index[0:3]
         # non unique
         index[6:9] = [index[6]]*3
-        
+
     data = xarray.Dataset({'uts': (('time'), index)}, coords={'time':index})
-    # need to create simple orbits here. Have start of first orbit 
-    # at 2009,1, 0 UT. 14.84 orbits per day	
+    # need to create simple orbits here. Have start of first orbit
+    # at 2009,1, 0 UT. 14.84 orbits per day
     time_delta = date  - root_date
     mlt = test.generate_fake_data(time_delta.total_seconds(), num_array,
                                   period=5820, data_range=[0.0, 24.0])
@@ -143,8 +143,7 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
                            dtype=np.int32))
     data['int64_dummy'] = (('time'), np.array([1] * len(data.indexes['time']),
                            dtype=np.int64))
-    # print (data['string_dummy'])
-
+    
     return data, meta.copy()
 
 

--- a/pysat/instruments/sw_kp.py
+++ b/pysat/instruments/sw_kp.py
@@ -368,7 +368,6 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
         sub_kps = [[], [], []]
         # iterate through file lines and parse out the info we want
         for line in raw_data:
-            # print (line)
             kp_time.append(pysat.datetime.strptime(line[0:10], '%Y %m %d'))
             # pick out Kp values for each of the three columns
             sub_lines = [line[17:33], line[40:56], line[63:]]

--- a/pysat/tests/test_ftp_instruments.py
+++ b/pysat/tests/test_ftp_instruments.py
@@ -75,9 +75,6 @@ init_mod = None
 init_names = None
 
 # this environment variable is set by the TRAVIS CI folks
-# print ("FTP Download check environment variable output ",
-#        os.environ.get('Travis'),
-#        os.environ.get('TRAVIS'), os.environ.get('CI'))
 if not (os.environ.get('TRAVIS') == 'true'):
     class TestFTPInstrumentQualifier(test_inst.TestInstrumentQualifier):
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -145,12 +145,12 @@ class TestBasics():
         # print(self.testInst.date)
         self.testInst.prev()
         test_date = self.testInst.index[0]
-        test_date = pysat.datetime(test_date.year, test_date.month, 
+        test_date = pysat.datetime(test_date.year, test_date.month,
                                    test_date.day)
         assert (test_date == pds.datetime(2009,1,3))  & \
                (test_date == self.testInst.date)
-        
-        
+
+
     #------------------------------------------------------------------------------
     #
     # Test date helpers
@@ -173,7 +173,7 @@ class TestBasics():
         today = pysat.datetime(now.year, now.month, now.day)
         self.testInst.date = now
         assert today == self.testInst.date
-     
+
     #------------------------------------------------------------------------------
     #
     # Test empty property flags, if True, no data
@@ -205,8 +205,8 @@ class TestBasics():
         if self.testInst.pandas_format:
             assert np.all(self.testInst.index == self.testInst.data.index)
         else:
-            assert np.all(self.testInst.index == 
-                          self.testInst.data.indexes['time'])    
+            assert np.all(self.testInst.index ==
+                          self.testInst.data.indexes['time'])
 
     #------------------------------------------------------------------------------
     #
@@ -246,7 +246,7 @@ class TestBasics():
     #
     # test instrument initialization functions
     #
-    #------------------------------------------------------------------------------                      
+    #------------------------------------------------------------------------------
     def test_instrument_init(self):
         """Test if init function supplied by instrument can modify object"""
         assert self.testInst.new_thing
@@ -460,8 +460,8 @@ class TestBasics():
             assert len(a) == 5
         else:
             assert a.sizes['time'] == 5
-                    
-                                                            
+
+
     #------------------------------------------------------------------------------
     #
     # Test iteration behaviors
@@ -482,15 +482,15 @@ class TestBasics():
         # load last data
         self.testInst.prev()
         # move on to future data that doesn't exist
-        self.testInst.next()       
+        self.testInst.next()
 
     def test_set_bounds_with_frequency(self):
         start = pysat.datetime(2009,1,1)
         stop = pysat.datetime(2010,1,15)
         self.testInst.bounds = (start, stop, 'M')
-        assert np.all(self.testInst._iter_list == pds.date_range(start, stop, 
+        assert np.all(self.testInst._iter_list == pds.date_range(start, stop,
                                                                  freq='M').tolist())
-                                                                                                                                                                                                                                
+
     @raises(ValueError)
     def test_set_bounds_too_few(self):
         start = pysat.datetime(2009,1,1)
@@ -507,23 +507,23 @@ class TestBasics():
         start = pysat.datetime(2009, 1, 1)
         stop = pysat.datetime(2009, 1, 15)
         self.testInst.bounds = (start, stop)
-        assert np.all(self.testInst._iter_list == 
+        assert np.all(self.testInst._iter_list ==
                       pds.date_range(start, stop).tolist())
 
     def test_set_bounds_by_default(self):
         start = self.testInst.files.start_date
         stop = self.testInst.files.stop_date
         self.testInst.bounds = (None, None)
-        assert np.all(self.testInst._iter_list == 
+        assert np.all(self.testInst._iter_list ==
                       pds.date_range(start, stop).tolist())
         self.testInst.bounds = None
-        assert np.all(self.testInst._iter_list == 
+        assert np.all(self.testInst._iter_list ==
                       pds.date_range(start, stop).tolist())
         self.testInst.bounds = (start, None)
-        assert np.all(self.testInst._iter_list == 
+        assert np.all(self.testInst._iter_list ==
                       pds.date_range(start, stop).tolist())
         self.testInst.bounds = (None, stop)
-        assert np.all(self.testInst._iter_list == 
+        assert np.all(self.testInst._iter_list ==
                       pds.date_range(start, stop).tolist())
 
     def test_set_bounds_by_date_extra_time(self):
@@ -532,7 +532,7 @@ class TestBasics():
         self.testInst.bounds = (start, stop)
         start = self.testInst._filter_datetime_input(start)
         stop = self.testInst._filter_datetime_input(stop)
-        assert np.all(self.testInst._iter_list == 
+        assert np.all(self.testInst._iter_list ==
                       pds.date_range(start, stop).tolist())
 
     def test_iterate_over_bounds_set_by_date(self):
@@ -545,7 +545,7 @@ class TestBasics():
         out = pds.date_range(start, stop).tolist()
         assert np.all(dates == out)
 
-        
+
     def test_iterate_over_bounds_set_by_date2(self):
         start = pysat.datetime(2008,1,1)
         stop = pysat.datetime(2010,12,31)
@@ -562,7 +562,7 @@ class TestBasics():
         self.testInst.bounds = (None, None)
         dates = []
         for inst in self.testInst:
-            dates.append(inst.date)            
+            dates.append(inst.date)
         out = pds.date_range(start, stop).tolist()
         assert np.all(dates == out)
 
@@ -605,7 +605,7 @@ class TestBasics():
         # iterate
         dates = []
         for inst in self.testInst:
-            dates.append(inst.date)            
+            dates.append(inst.date)
         out = pds.date_range(start[0], stop[0]).tolist()
         out.extend(pds.date_range(start[1], stop[1]).tolist())
         assert np.all(dates == out)
@@ -729,8 +729,8 @@ class TestBasicsShiftedFileDates(TestBasics):
     def setup(self):
         re_load(pysat.instruments.pysat_testing)
         """Runs before every method to create a clean testing setup."""
-        self.testInst = pysat.Instrument('pysat', 'testing', 
-                                         sat_id='10', 
+        self.testInst = pysat.Instrument('pysat', 'testing',
+                                         sat_id='10',
                                          clean_level='clean',
                                          update_files=True,
                                          mangle_file_dates=True,
@@ -752,8 +752,8 @@ class TestMalformedIndex():
     def setup(self):
         re_load(pysat.instruments.pysat_testing)
         """Runs before every method to create a clean testing setup."""
-        self.testInst = pysat.Instrument('pysat', 'testing', 
-                                         sat_id='10', 
+        self.testInst = pysat.Instrument('pysat', 'testing',
+                                         sat_id='10',
                                          clean_level='clean',
                                          malformed_index=True,
                                          update_files=True,
@@ -782,8 +782,8 @@ class TestMalformedIndexXarray(TestMalformedIndex):
     def setup(self):
         re_load(pysat.instruments.pysat_testing)
         """Runs before every method to create a clean testing setup."""
-        self.testInst = pysat.Instrument('pysat', 'testing_xarray', 
-                                         sat_id='10', 
+        self.testInst = pysat.Instrument('pysat', 'testing_xarray',
+                                         sat_id='10',
                                          clean_level='clean',
                                          malformed_index=True,
                                          update_files=True,
@@ -890,16 +890,11 @@ class TestDataPaddingbyFile():
         self.testInst.load(fid=1, verifyPad=True)
         test_index = pds.date_range(self.testInst.index[0],
                                     self.testInst.index[-1], freq='S')
-        # print (test_index[0], test_index[-1], len(test_index))
-        # print(self.testInst.index[0], self.testInst.index[-1],
-        #       len(self.testInst.data))
         assert (np.all(self.testInst.index == test_index))
 
     def test_fid_data_padding_removal(self):
         self.testInst.load(fid=1)
         self.rawInst.load(fid=1)
-        # print(self.testInst.index)
-        # print(new_inst.data.index)
         assert self.testInst.index[0] == self.rawInst.index[0]
         assert self.testInst.index[-1] == self.rawInst.index[-1]
         assert len(self.rawInst.data) == len(self.testInst.data)

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -247,7 +247,6 @@ class TestInstrumentQualifier():
         import os
 
         start = inst.test_dates[inst.sat_id][inst.tag]
-        # print (start)
         try:
             # check for username
             inst_name = '_'.join((inst.platform, inst.name))

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -315,12 +315,10 @@ class TestBasics():
         aa = self.meta.pop('new3')
         assert np.all(aa['children'] == meta2)
         # ensure lower metadata created when ho data assigned
-        # print (aa['units'])
         assert aa['units'] == ''
         assert aa['long_name'] == 'new3'
         m1 = self.meta['new2']
         m2 = self.meta.pop('new2')
-        # assert np.all(bb == cc)
         assert m1['children'] is None
         assert m2['children'] is None
         for key in m1.index:
@@ -703,7 +701,6 @@ class TestBasics():
     def test_multiple_input_names_null_value_preexisting_values(self):
         self.meta[['test1', 'test2']] = {'units': ['degrees', 'hams'],
                                          'long_name': ['testing', 'further']}
-        # print (self.meta)
         self.meta[['test1', 'test2']] = {}
         check1 = self.meta['test1', 'units'] == 'degrees'
         check2 = self.meta['test2', 'long_name'] == 'further'
@@ -725,8 +722,6 @@ class TestBasics():
         self.meta = pysat.Meta(units_label='Units', name_label='Long_Name')
         self.meta['new'] = {'Units': 'hey', 'Long_Name': 'boo'}
         self.meta['new2'] = {'Units': 'hey2', 'Long_Name': 'boo2'}
-        # print ( self.meta['new'])
-        # print (self.meta['new2', 'units'])
         self.meta['new'].units
 
     def test_get_Units_wrong_case(self):
@@ -762,12 +757,10 @@ class TestBasics():
             self.meta['new_%d' % i] = {'units': 'heyhey%d' % i,
                                        'long_name': 'booboo%d' % i}
 
-        # print (self.meta['new'])
         assert self.meta['new'].Units == 'hey9'
         assert self.meta['new'].Long_Name == 'boo9'
         assert self.meta['new_9'].Units == 'heyhey9'
         assert self.meta['new_9'].Long_Name == 'booboo9'
-        # print (self.meta['new_500'])
         assert self.meta['new_5'].Units == 'hey9'
         assert self.meta['new_5'].Long_Name == 'boo9'
 
@@ -777,7 +770,6 @@ class TestBasics():
         self.meta['new2'] = {'units': 'hey2', 'long_name': 'boo2'}
         self.meta.units_label = 'Units'
         self.meta.name_label = 'Long_Name'
-        # print(self.meta['new'])
         assert ((self.meta['new'].Units == 'hey') &
                 (self.meta['new'].Long_Name == 'boo') &
                 (self.meta['new2'].Units == 'hey2') &
@@ -791,7 +783,6 @@ class TestBasics():
         self.meta['new2'] = meta2
         self.meta.units_label = 'Units'
         self.meta.name_label = 'Long_Name'
-        # print(self.meta['new'])
         assert ((self.meta['new'].Units == 'hey') &
                 (self.meta['new'].Long_Name == 'boo') &
                 (self.meta['new2'].children['new21'].Units == 'hey2') &
@@ -806,7 +797,6 @@ class TestBasics():
         self.meta['new2'] = meta2
         self.meta.units_label = 'Units'
         self.meta.name_label = 'Long_Name'
-        # print(self.meta['new'])
         assert ((self.meta['new'].units == 'hey') &
                 (self.meta['new'].long_name == 'boo') &
                 (self.meta['new2'].children['new21'].units == 'hey2') &

--- a/pysat/tests/test_orbits.py
+++ b/pysat/tests/test_orbits.py
@@ -24,8 +24,6 @@ class TestSpecificUTOrbits():
         self.testInst.orbits[0]
         ans = (self.testInst.index[0] == pds.datetime(2009, 1, 1))
         ans2 = (self.testInst.index[-1] == pds.datetime(2009, 1, 1, 1, 36, 59))
-        # print (ans,ans2)
-        # print (self.testInst.index[0], self.testInst.index[-1])
         assert ans & ans2
 
     def test_single_orbit_call_by_1_index(self):
@@ -33,8 +31,6 @@ class TestSpecificUTOrbits():
         self.testInst.orbits[1]
         ans = (self.testInst.index[0] == pds.datetime(2009, 1, 1, 1, 37))
         ans2 = (self.testInst.index[-1] == pds.datetime(2009, 1, 1, 3, 13, 59))
-        # print (ans,ans2)
-        # print (self.testInst.index[0], self.testInst.index[-1])
         assert ans & ans2
 
     def test_single_orbit_call_by_negative_1_index(self):
@@ -106,9 +102,6 @@ class TestSpecificUTOrbits():
         from dateutil.relativedelta import relativedelta as relativedelta
         self.testInst.load(2008, 366)
         self.testInst.orbits.next()
-        # print self.testInst.index[0], pds.datetime(2008,12,30, 23, 45),
-        # self.testInst.index[-1], (pds.datetime(2008,12,30, 23, 45)+
-        # relativedelta(hours=1, minutes=36, seconds=59))
         assert (self.testInst.index[0] == pds.datetime(2008, 12, 30, 23, 45))
         assert (self.testInst.index[-1] ==
                 (pds.datetime(2008, 12, 30, 23, 45) +

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -24,7 +24,6 @@ def prep_dir(inst=None):
     # create data directories
     try:
         os.makedirs(inst.files.data_path)
-        # print ('Made Directory')
     except OSError:
         pass
 
@@ -239,8 +238,6 @@ class TestBasicNetCDF4():
 
         # test Series of DataFrames
         test_list = []
-        # print (loaded_inst.columns)
-        # print (loaded_inst)
         for frame1, frame2 in zip(test_inst.data['profiles'],
                                   loaded_inst['profiles']):
             test_list.append(np.all((frame1 == frame2).all()))
@@ -258,10 +255,8 @@ class TestBasicNetCDF4():
         for frame1, frame2 in zip(test_inst.data['series_profiles'],
                                   loaded_inst['series_profiles']):
             test_list.append(np.all((frame1 == frame2).all()))
-            # print frame1, frame2
         loaded_inst.drop('series_profiles', inplace=True, axis=1)
         test_inst.data.drop('series_profiles', inplace=True, axis=1)
 
         assert (np.all((test_inst.data == loaded_inst).all()))
-        # print (test_list)
         assert np.all(test_list)

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -247,7 +247,6 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
                             data.variables[key].getncattr(nc_key)
                     dim_meta_data[clean_key] = meta_dict
 
-                # print (dim_meta_data)
                 dim_meta_dict = {'meta': dim_meta_data}
                 if index_key_name is not None:
                     # add top level meta
@@ -305,8 +304,7 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
                         loop_list.append(loop_frame.iloc[step_size*i:step_size*(i+1)])
                         loop_list[-1].index = new_index[step_size*i:step_size*(i+1)]
                         loop_list[-1].index.name = new_index_name
-                # print (loop_frame.columns)
-
+                
                 # add 2D object data, all based on a unique dimension within
                 # netCDF, to loaded data dictionary
                 loadedVars[obj_key_name] = loop_list


### PR DESCRIPTION
Removed the last of the legacy print statements via 'find all'. Remaining legacy statements all in comments.  Example lines in documentation have been converted to be python 3 compatible. Commented lines have been removed. 