### PR TITLE
Limit pandas to < 0.25

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ if sys.version_info.major == 2:
                         'pysatMagVect', 'madrigalWeb', 'h5py',
                         'PyForecastTools', 'pyglow']
 else:
-    install_requires = ['xarray', 'pandas>=0.23', 'numpy>=1.12',
+    install_requires = ['xarray', 'pandas>=0.23, <0.25', 'numpy>=1.12',
                         'sgp4', 'pyEphem', 'requests', 'beautifulsoup4',
                         'lxml', 'pysatCDF', 'apexpy', 'aacgmv2',
                         'pysatMagVect', 'madrigalWeb', 'h5py',


### PR DESCRIPTION
The pandas apocalypse is at hand!

Pandas 0.25 has removed panel.  Adding an upper limit to pandas version to keep the code moving.