### PR TITLE
Utils bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.X.X] - 2019-07-17
+- Bug fix
+   - Fixed implementation of utils routines in model_utils and jro_isr
+
 ## [2.0.0] - 2019-07-??
  - New Features
    - `pysatData` directory created in user's home directory if no directory specified

--- a/pysat/instruments/jro_isr.py
+++ b/pysat/instruments/jro_isr.py
@@ -229,7 +229,7 @@ def calc_measurement_loc(self):
 
     """
 
-    from pysat import utils
+    from pysat.utils import coords
 
     az_keys = [kk[5:] for kk in list(self.data.keys())
                if kk.find('azdir') == 0]
@@ -257,13 +257,13 @@ def calc_measurement_loc(self):
         # JRO is located 520 m above sea level (jro.igp.gob.pe./english/)
         # Also, altitude has already been calculated
         gdaltr = np.ones(shape=self['gdlonr'].shape) * 0.52
-        gdlat, gdlon, _ = utils.local_horizontal_to_global_geo(self[az_key],
-                                                               self[el_key],
-                                                               self['range'],
-                                                               self['gdlatr'],
-                                                               self['gdlonr'],
-                                                               gdaltr,
-                                                               geodetic=True)
+        gdlat, gdlon, _ = coords.local_horizontal_to_global_geo(self[az_key],
+                                                                self[el_key],
+                                                                self['range'],
+                                                                self['gdlatr'],
+                                                                self['gdlonr'],
+                                                                gdaltr,
+                                                                geodetic=True)
 
         # Assigning as data, to ensure that the number of coordinates match
         # the number of data dimensions

--- a/pysat/model_utils.py
+++ b/pysat/model_utils.py
@@ -186,8 +186,8 @@ def compare_model_and_inst(pairs=None, inst_name=[], mod_name=[],
     # Cycle through all of the data types
     for i, iname in enumerate(inst_name):
         # Determine whether the model data needs to be scaled
-        iscale = utils.scale_units(pairs.data_vars[iname].units,
-                                   pairs.data_vars[mod_name[i]].units)
+        iscale = utils.coords.scale_units(pairs.data_vars[iname].units,
+                                          pairs.data_vars[mod_name[i]].units)
         mod_scaled = pairs.data_vars[mod_name[i]].values.flatten() * iscale
 
         # Flatten both data sets, since accuracy routines require 1D arrays
@@ -350,7 +350,7 @@ def collect_inst_model_pairs(start=None, stop=None, tinc=None, inst=None,
         if mdata is not None:
             # Load the instrument data, if needed
             if inst.empty or inst.index[-1] < istart:
-                inst.custom.add(pysat.utils.update_longitude, 'modify',
+                inst.custom.add(pysat.utils.coords.update_longitude, 'modify',
                                 low=lon_low, lon_name=inst_lon_name,
                                 high=lon_high)
                 inst.load(date=istart)
@@ -510,8 +510,8 @@ def extract_modelled_observations(inst=None, model=None, inst_name=[],
         if ii not in list(inst.data.keys()):
             raise ValueError('Unknown instrument location index ' +
                              '{:}'.format(ii))
-        inst_scale[i] = utils.scale_units(mod_units[i],
-                                          inst.meta.data.units[ii])
+        inst_scale[i] = utils.coords.scale_units(mod_units[i],
+                                                 inst.meta.data.units[ii])
 
     # Determine which data to interpolate and initialize the interpolated
     # output

--- a/pysat/tests/test_model_utils.py
+++ b/pysat/tests/test_model_utils.py
@@ -1,0 +1,38 @@
+import numpy as np
+import sys
+
+from nose.tools import assert_raises, raises
+import pandas as pds
+
+import pysat
+from pysat import model_utils as mu
+
+
+class TestBasics():
+    def setup(self):
+        """Runs before every method to create a clean testing setup."""
+        self.testInst = pysat.Instrument(platform='pysat',
+                                         name='testing',
+                                         clean_level='clean')
+        self.start = pysat.datetime(2009, 1, 1)
+        self.stop = pysat.datetime(2009, 1, 1)
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.testInst, self.start, self.stop
+
+    @raises(ValueError)
+    def test_collect_inst_model_pairs_wo_date(self):
+        """Try to run without start or stop dates"""
+        match = mu.collect_inst_model_pairs(inst=self.testInst)
+
+    @raises(ValueError)
+    def test_collect_inst_model_pairs_wo_inst(self):
+        """Try to run without an instrument"""
+        match = mu.collect_inst_model_pairs(start=self.start, stop=self.stop)
+
+    @raises(ValueError)
+    def test_collect_inst_model_pairs_wo_model(self):
+        """Try to run without a model"""
+        match = mu.collect_inst_model_pairs(start=self.start, stop=self.stop,
+                                            inst=self.testInst)


### PR DESCRIPTION
Description:
Fixes calls to utils routines. Addresses #255 .

Type of change:
Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?
Try running compare_model_and_inst, collect_inst_model_pairs, or extract_modelled_observations in pysat.model_utils. In the old version these would fail and now they won't.

Download JRO ISR data and apply the pysat.instruments.jro_isr.calc_measurement_loc test when loading the data. The old version would fail and now it won't.

Test Configuration:

OSX Sierra

Checklist:
  [x] Make sure you are merging into the develop (not master) branch
   [x] My code follows the style guidelines of this project
   [x] I have performed a self-review of my own code
   [x] I have commented my code, particularly in hard-to-understand areas
  [x]  I have made corresponding changes to the documentation
   [x] My changes generate no new warnings
  [ ]  I have added tests that prove my fix is effective or that my feature works
  [x]  New and existing unit tests pass locally with my changes
   [x] Any dependent changes have been merged and published in downstream modules
  [x]  Add a note to CHANGELOG.md, summarizing the changes