### PR TITLE
BUG: LASP file format change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bug fix
    - Fixed implementation of utils routines in model_utils and jro_isr
    - Fixed error catching bug in model_utils
+   - Fixed error introduced by upstream change in NOAA F10.7 file format
 
 ## [2.0.0] - 2019-07-11
  - New Features

--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -383,8 +383,14 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
             if data.empty:
                 warnings.warn("no data for {:}".format(date), UserWarning)
             else:
-                times = [pysat.datetime.strptime(time, '%Y %m %d')
-                         for time in data.pop('time')]
+                try:
+                    # This is the new data format
+                    times = [pysat.datetime.strptime(time, '%Y%m%d')
+                             for time in data.pop('time')]
+                except ValueError:
+                    # Accepts old file formats
+                    times = [pysat.datetime.strptime(time, '%Y %m %d')
+                             for time in data.pop('time')]
                 data.index = times
                 # replace fill with NaNs
                 idx, = np.where(data['f107'] == -99999.0)

--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -382,14 +382,8 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
             if data.empty:
                 warnings.warn("no data for {:}".format(date), UserWarning)
             else:
-                try:
-                    # This is the new data format
-                    times = [pysat.datetime.strptime(time, '%Y%m%d')
-                             for time in data.pop('time')]
-                except ValueError:
-                    # Accepts old file formats
-                    times = [pysat.datetime.strptime(time, '%Y %m %d')
-                             for time in data.pop('time')]
+                times = [pysat.datetime.strptime(time, '%Y%m%d')
+                         for time in data.pop('time')]
                 data.index = times
                 # replace fill with NaNs
                 idx, = np.where(data['f107'] == -99999.0)

--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -43,7 +43,6 @@ is not appropriate for 'forecast' data.
 """
 
 import os
-import functools
 import warnings
 
 import numpy as np
@@ -444,8 +443,8 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
 
         bad_fname = list()
 
-        # Get the local files, to ensure that the version 1 files are downloaded
-        # again if more data has been added
+        # Get the local files, to ensure that the version 1 files are
+        # downloaded again if more data has been added
         local_files = list_files(tag, sat_id, data_path)
 
         # To avoid downloading multiple files, cycle dates based on file length
@@ -453,7 +452,7 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
         while date <= date_array[-1]:
             # The file name changes, depending on how recent the requested
             # data is
-            qnum = (date.month-1) // 3 + 1 # Integer floor division
+            qnum = (date.month-1) // 3 + 1  # Integer floor division
             qmonth = (qnum-1) * 3 + 1
             quar = 'Q{:d}_'.format(qnum)
             fnames = ['{:04d}{:s}DSD.txt'.format(date.year, ss)

--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -411,8 +411,14 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
         # process
         raw_dict = json.loads(r.text)['noaa_radio_flux']
         data = pds.DataFrame.from_dict(raw_dict['samples'])
-        times = [pysat.datetime.strptime(time, '%Y %m %d')
-                 for time in data.pop('time')]
+        try:
+            # This is the new data format
+            times = [pysat.datetime.strptime(time, '%Y%m%d')
+                     for time in data.pop('time')]
+        except ValueError:
+            # Accepts old file formats
+            times = [pysat.datetime.strptime(time, '%Y %m %d')
+                     for time in data.pop('time')]
         data.index = times
         # replace fill with NaNs
         idx, = np.where(data['f107'] == -99999.0)


### PR DESCRIPTION
# Description

The LASP file format for F10.7 data changed (time format condensed into a single string).  This fixes the way time is cast into a datetime object based on the new file format.  In case people want to access their old files, that option still exists.

Addresses #273 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test will download data without any errors.

```
import pysat                                                            
f107 = pysat.Instrument('sw', 'f107')                                   
d = pysat.datetime(2009,1,1)                                            
f107.download(d,d)
```

**Test Configuration**:
* OS X Sierra

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
