### PR TITLE
ENH: prevent multiple kp downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Added option to to_netCDF that names variables in the written file
    based upon the strings in the Instrument.meta object
    - Improved compatibility with NASA ICON's file standards
+   - Improved file downloading for Kp
 - Bug fix
    - Fixed implementation of utils routines in model_utils and jro_isr
    - Fixed error catching bug in model_utils

--- a/pysat/instruments/sw_kp.py
+++ b/pysat/instruments/sw_kp.py
@@ -284,6 +284,7 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
         ftp = FTP('ftp.gfz-potsdam.de')   # connect to host, default port
         ftp.login()               # user anonymous, passwd anonymous@
         ftp.cwd('/pub/home/obs/kp-ap/tab')
+        dnames = list()
 
         for date in date_array:
             fname = 'kp{year:02d}{month:02d}.tab'
@@ -291,19 +292,21 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
                                  month=date.month)
             local_fname = fname
             saved_fname = os.path.join(data_path, local_fname)
-            try:
-                print('Downloading file for '+date.strftime('%x'))
-                sys.stdout.flush()
-                ftp.retrbinary('RETR '+fname, open(saved_fname, 'wb').write)
-            except ftplib.error_perm as exception:
+            if not fname in dnames:
+                try:
+                    print('Downloading file for '+date.strftime('%b %Y'))
+                    sys.stdout.flush()
+                    ftp.retrbinary('RETR '+fname, open(saved_fname, 'wb').write)
+                    dnames.append(fname)
+                except ftplib.error_perm as exception:
 
-                if str(exception.args[0]).split(" ", 1)[0] != '550':
-                    raise
-                else:
-                    # file isn't actually there, just let people know
-                    # then continue on
-                    os.remove(saved_fname)
-                    print('File not available for '+date.strftime('%x'))
+                    if str(exception.args[0]).split(" ", 1)[0] != '550':
+                        raise
+                    else:
+                        # file isn't actually there, just let people know
+                        # then continue on
+                        os.remove(saved_fname)
+                        print('File not available for '+date.strftime('%x'))
 
         ftp.close()
 


### PR DESCRIPTION
# Description

Since Kp files contain a month of data and pysat dates cycle at a daily cadance, test to see if a file was downloaded before grabbing it again.  Will reduce the number of ftp timeouts.

Addresses #280 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested by downloading a month of data using standard download inputs.  It will probably time out when this change isn't in place.  This should fix the Travis-CI issue for Kp downloads.

**Test Configuration**:
* OSX Sierra
* Python 2.7 (still!)

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
