### PR TITLE
instrument label slicing

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -445,9 +445,9 @@ class Instrument(object):
                 except:
                     try:
                         return self.data.sel(time=key[0])[key[1]]
-                    except: # construct dataset from names
+                    except TypeError: # construct dataset from names
                         variables = list(self.data.variables.keys())[key[1]]
-                        dataset_dict = {v: self.data[v] for v in variables if v not in self.data.coords}
+                        dataset_dict = {variable: self.data[variable] for variable in variables if variable not in self.data.coords}
                         return xr.Dataset(dataset_dict, coords = self.data.coords, attrs = self.data.attrs)
             else:
                 # multidimensional indexing

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -446,9 +446,7 @@ class Instrument(object):
                     try:
                         return self.data.sel(time=key[0])[key[1]]
                     except TypeError: # construct dataset from names
-                        variables = list(self.data.variables.keys())[key[1]]
-                        dataset_dict = {variable: self.data[variable] for variable in variables if variable not in self.data.coords}
-                        return xr.Dataset(dataset_dict, coords = self.data.coords, attrs = self.data.attrs)
+                        return self.data[self.variables[key[1]]]
             else:
                 # multidimensional indexing
                 indict = {}

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -443,7 +443,12 @@ class Instrument(object):
                 try:
                     return self.data.isel(time=key[0])[key[1]]
                 except:
-                    return self.data.sel(time=key[0])[key[1]]
+                    try:
+                        return self.data.sel(time=key[0])[key[1]]
+                    except: # construct dataset from names
+                        variables = list(self.data.variables.keys())[key[1]]
+                        dataset_dict = {v: self.data[v] for v in variables if v not in self.data.coords}
+                        return xr.Dataset(dataset_dict, coords = self.data.coords, attrs = self.data.attrs)
             else:
                 # multidimensional indexing
                 indict = {}

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -218,9 +218,10 @@ class TestBasics():
             data2 = data2.rename({'time':'time2'})
 
             # concat together
-            self.testInst.data = self.testInst.concat_data([data1, data2], dim='time2').rename({'time2':'time'})
+            self.testInst.data = self.testInst.concat_data([data1, data2], dim='time2').rename({'time2': 'time'})
             # test for concatenation
-            len3 = len(self.testInst.index) # Instrument.data must have a 'time' index 
+            # Instrument.data must have a 'time' index 
+            len3 = len(self.testInst.index) 
             assert (len3 == len1 + len2)
             assert ((self.testInst[0:len1, :] == data1.to_array()[:, :]).all().all() & 
                     (self.testInst[len1:, :] == data2.to_array()[:, :]).all().all()) 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -353,6 +353,14 @@ class TestBasics():
         assert np.all(self.testInst[0:10, 'uts'] ==
                       self.testInst.data['uts'].values[0:10])
 
+    def test_data_access_by_row_slicing_and_name_slicing(self):
+        self.testInst.load(2009, 1)
+        result = self.testInst[0:10,:]
+        for variable, array in result.items():
+            assert len(array) == len(self.testInst.data[variable].values[0:10])
+            assert np.all(array == self.testInst.data[variable].values[0:10])
+
+
     def test_data_access_by_row_slicing_w_ndarray_and_name(self):
         self.testInst.load(2009, 1)
         assert np.all(self.testInst[np.arange(0, 10), 'uts'] ==

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -195,29 +195,35 @@ class TestBasics():
         # test for concatenation
         len3 = len(self.testInst.index)
         assert (len3 == len1 + len2)
-        assert ((self.testInst[0:len1, :] == data1[:, :]).all().all() & 
-                (self.testInst[len1:, :] == data2[:, :]).all().all()) 
 
         # concat together with sort=True
         if self.testInst.pandas_format:
+            assert ((self.testInst[0:len1, :] == data1.values[:, :]).all().all() & 
+                    (self.testInst[len1:, :] == data2.values[:, :]).all().all()) 
             self.testInst.data = self.testInst.concat_data([data1, data2], sort=True)
             # test for concatenation
             len3 = len(self.testInst.index)
             assert (len3 == len1 + len2)
-            assert ((self.testInst[0:len1, data1.columns] == data1[:, :]).all().all() & 
-                    (self.testInst[len1:, data2.columns] == data2[:, :]).all().all()) 
+            assert ((self.testInst[0:len1, data1.columns] == data1.values[:, :]).all().all() & 
+                    (self.testInst[len1:, data2.columns] == data2.values[:, :]).all().all()) 
         else:
             # xarray
+
+            assert ((self.testInst[0:len1, :] == data1.to_array()[:, :]).all().all() & 
+                    (self.testInst[len1:, :] == data2.to_array()[:, :]).all().all()) 
+
+
             # test for dim keyword
-            data1.indexes['time2'] = data1.indexes['time']
-            data2.indexes['time2'] = data2.indexes['time']
+            data1 = data1.rename({'time':'time2'})
+            data2 = data2.rename({'time':'time2'})
+
             # concat together
-            self.testInst.data = self.testInst.concat_data([data1, data2], dim='time2')
+            self.testInst.data = self.testInst.concat_data([data1, data2], dim='time2').rename({'time2':'time'})
             # test for concatenation
-            len3 = len(self.testInst.index)
+            len3 = len(self.testInst.index) # Instrument.data must have a 'time' index 
             assert (len3 == len1 + len2)
-            assert ((self.testInst[0:len1, :] == data1[:, :]).all().all() & 
-                    (self.testInst[len1:, :] == data2[:, :]).all().all()) 
+            assert ((self.testInst[0:len1, :] == data1.to_array()[:, :]).all().all() & 
+                    (self.testInst[len1:, :] == data2.to_array()[:, :]).all().all()) 
 
 
     #------------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Addresses # 262

`testInst[:,:]` was broken, so I added label slicing for instruments, which was causing tests to fail.

Modified the instrument test for pandas to slice values instead of index. 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update (possibly)



# How Has This Been Tested?
`pysat/tests/test_instrument.py` passes

**Test Configuration**:
* Mac 10.13.6
* miniconda python==3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
